### PR TITLE
Fix #10: Implement ReferenceProvider to navigate from symbol to usages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,6 @@ lazy val cli = project
     mainClass.in(assembly) := Some("metadoc.cli.MetadocCli"),
     assemblyJarName.in(assembly) := "metadoc.jar",
     libraryDependencies ++= List(
-      "org.scalameta" %% "scalameta" % "1.8.0",
       "com.github.alexarchambault" %% "case-app" % "1.2.0-M3",
       "com.github.pathikrit" %% "better-files" % "3.0.0"
     )
@@ -70,7 +69,6 @@ lazy val js = project
     emitSourceMaps := false, // Disabled to reduce warnings
     webpackConfigFile := Some(baseDirectory.value / "webpack.config.js"),
     libraryDependencies ++= Seq(
-      "org.scalameta" %%% "scalameta" % "1.8.0",
       "org.scala-js" %%% "scalajs-dom" % "0.9.2"
     ),
     npmDevDependencies in Compile ++= Seq(
@@ -110,6 +108,7 @@ lazy val core = crossProject
       baseDirectory.value./("../src/main/protobuf")
     ),
     libraryDependencies ++= List(
+      "org.scalameta" %%% "scalameta" % "1.8.0",
       "com.trueaccord.scalapb" %%% "scalapb-runtime" % scalapbVersion
     )
   )

--- a/metadoc-core/src/main/scala/metadoc/IndexLookup.scala
+++ b/metadoc-core/src/main/scala/metadoc/IndexLookup.scala
@@ -1,0 +1,38 @@
+package metadoc
+
+import scala.meta.Attributes
+import metadoc.schema.{Index, Position, Symbol}
+
+object IndexLookup {
+  def findDefinition(
+      offset: Int,
+      attrs: Attributes,
+      index: Index
+  ): Option[Position] =
+    findSymbol(offset, attrs, index).flatMap(_.definition)
+
+  def findReferences(
+      offset: Int,
+      includeDeclaration: Boolean,
+      attrs: Attributes,
+      index: Index
+  ): Seq[Position] =
+    findSymbol(offset, attrs, index).toSeq.flatMap {
+      case Symbol(_, definition, references) =>
+        references ++ definition.filter(_ => includeDeclaration)
+    }
+
+  def findSymbol(
+      offset: Int,
+      attrs: Attributes,
+      index: Index
+  ): Option[Symbol] =
+    for {
+      name <- attrs.names.collectFirst {
+        case (pos, sym)
+            if pos.start.offset <= offset && offset <= pos.end.offset =>
+          sym.syntax
+      }
+      symbol <- index.symbols.find(_.symbol == name)
+    } yield symbol
+}

--- a/metadoc-core/src/test/scala/metadoc/IndexLookupTest.scala
+++ b/metadoc-core/src/test/scala/metadoc/IndexLookupTest.scala
@@ -1,0 +1,64 @@
+package metadoc
+
+import org.scalatest.FunSuite
+import scala.collection.immutable.Seq
+import scala.meta._
+import metadoc.{schema => doc}
+
+class IndexLookupTest extends FunSuite {
+  val attrs = Attributes(
+    dialect = dialects.Scala212,
+    names = Seq(
+      (Position.Range(Input.String("src/p/C.scala"), 1, 5), Symbol.Local("p.C")),
+      (Position.Range(Input.String("src/p/C.scala"), 6, 10), Symbol.Local("p.fun")),
+      (Position.Range(Input.String("src/p/C.scala"), 11, 14), Symbol.Local("lib.no")),
+    ),
+    messages = Seq.empty,
+    denotations = Seq.empty,
+    sugars = Seq.empty
+  )
+
+  val cDefinition = Some(doc.Position("src/p/C.scala", 1, 5))
+  val cReferences = Seq(
+    doc.Position("src/p/C.scala", 20, 25),
+    doc.Position("src/p/C.scala", 30, 35)
+  )
+  val cSymbol = doc.Symbol("p.C", cDefinition, cReferences)
+
+  val funDefinition = Some(doc.Position("src/p/C.scala", 6, 10))
+  val funReferences = Seq(doc.Position("src/p/C.scala", 40, 45))
+  val funSymbol = doc.Symbol("p.fun", funDefinition, funReferences)
+
+  val noDefinition = None
+  val noReferences = Seq(doc.Position("src/p/C.scala", 37, 39))
+  val noSymbol = doc.Symbol("lib.no", noDefinition, noReferences)
+
+  val index = doc.Index(
+    files = Seq("src/p/C.scala"),
+    symbols = Seq(cSymbol, funSymbol, noSymbol)
+  )
+
+  test("IndexLookup.findSymbol") {
+    assert(IndexLookup.findSymbol(0, attrs, index) == None)
+    assert(IndexLookup.findSymbol(1, attrs, index) == Some(cSymbol))
+    assert(IndexLookup.findSymbol(5, attrs, index) == Some(cSymbol))
+    assert(IndexLookup.findSymbol(6, attrs, index) == Some(funSymbol))
+    assert(IndexLookup.findSymbol(11, attrs, index) == Some(noSymbol))
+    assert(IndexLookup.findSymbol(14, attrs, index) == Some(noSymbol))
+    assert(IndexLookup.findSymbol(15, attrs, index) == None)
+  }
+
+  test("IndexLookup.findDefinition") {
+    assert(IndexLookup.findDefinition(3, attrs, index) == cDefinition)
+    assert(IndexLookup.findDefinition(8, attrs, index) == funDefinition)
+    assert(IndexLookup.findDefinition(0, attrs, index) == None)
+  }
+
+  test("IndexLookup.findReferences") {
+    assert(IndexLookup.findReferences(3, true, attrs, index) == (cReferences ++ cDefinition))
+    assert(IndexLookup.findReferences(3, false, attrs, index) == cReferences)
+    assert(IndexLookup.findReferences(11, true, attrs, index) == noReferences)
+    assert(IndexLookup.findReferences(0, true, attrs, index).isEmpty)
+    assert(IndexLookup.findReferences(0, false, attrs, index).isEmpty)
+  }
+}

--- a/metadoc-js/src/main/scala/metadoc/Metadoc.scala
+++ b/metadoc-js/src/main/scala/metadoc/Metadoc.scala
@@ -52,6 +52,10 @@ object MetadocApp extends js.JSApp {
       ScalaLanguageExtensionPoint.id,
       new ScalaDefinitionProvider(attrs, index)
     )
+    monaco.languages.Languages.registerReferenceProvider(
+      ScalaLanguageExtensionPoint.id,
+      new ScalaReferenceProvider(attrs, index)
+    )
     dom.document.getElementById("title").textContent = fileName
 
     val options = jsObject[IEditorConstructionOptions]

--- a/metadoc-js/src/main/scala/metadoc/ScalaDefinitionProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaDefinitionProvider.scala
@@ -16,36 +16,9 @@ class ScalaDefinitionProvider(attrs: Attributes, index: Index)
       position: monaco.Position,
       token: monaco.CancellationToken
   ) = {
-
     val offset = model.getOffsetAt(position)
-
-    val symbol: Option[String] = attrs.names.collectFirst {
-      case (pos, sym)
-          if pos.start.offset <= offset && offset <= pos.end.offset =>
-        sym.syntax
-    }
-    val maybeDefinition = symbol.flatMap { sym =>
-      index.symbols.collectFirst {
-        case Symbol(name, Some(definition), _) if sym == name =>
-          definition
-      }
-    }
-
-    maybeDefinition match {
-      case Some(definition) =>
-        val startPos = model.getPositionAt(definition.start)
-        val endPos = model.getPositionAt(definition.end)
-        val range = new monaco.Range(
-          startPos.lineNumber,
-          startPos.column,
-          endPos.lineNumber,
-          endPos.column
-        )
-
-        // FIXME: check definition.filename and reload
-        new Location(model.uri, range)
-      case None =>
-        js.Array[Location]()
-    }
+    val definition = IndexLookup.findDefinition(offset, attrs, index)
+    val locations = definition.map(resolveLocation(model))
+    js.Array[Location](locations.toSeq: _*)
   }
 }

--- a/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
@@ -1,0 +1,30 @@
+package metadoc
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+import scala.meta.Attributes
+import metadoc.schema.{Index, Symbol}
+import monaco.{CancellationToken, Position}
+import monaco.editor.IReadOnlyModel
+import monaco.languages.{Location, ReferenceContext, ReferenceProvider}
+
+@ScalaJSDefined
+class ScalaReferenceProvider(attrs: Attributes, index: Index)
+    extends ReferenceProvider {
+  override def provideReferences(
+      model: IReadOnlyModel,
+      position: Position,
+      context: ReferenceContext,
+      token: CancellationToken
+  ) = {
+    val offset = model.getOffsetAt(position)
+    val positions = IndexLookup.findReferences(
+      offset,
+      context.includeDeclaration,
+      attrs,
+      index
+    )
+    val locations = positions.map(resolveLocation(model))
+    js.Array[Location](locations: _*)
+  }
+}

--- a/metadoc-js/src/main/scala/metadoc/package.scala
+++ b/metadoc-js/src/main/scala/metadoc/package.scala
@@ -1,5 +1,10 @@
 import scala.scalajs.js
 
+import metadoc.schema.Position
+import monaco.editor.IReadOnlyModel
+import monaco.languages.Location
+import monaco.Range
+
 package object metadoc {
 
   /**
@@ -22,4 +27,18 @@ package object metadoc {
     */
   def jsObject[T <: js.Object]: T =
     (new js.Object()).asInstanceOf[T]
+
+  def resolveLocation(model: IReadOnlyModel)(pos: Position) = {
+    val startPos = model.getPositionAt(pos.start)
+    val endPos = model.getPositionAt(pos.end)
+    val range = new Range(
+      startPos.lineNumber,
+      startPos.column,
+      endPos.lineNumber,
+      endPos.column
+    )
+
+    // FIXME: load new file content
+    new Location(model.uri, range)
+  }
 }

--- a/metadoc-js/src/main/scala/monaco/Monaco.scala
+++ b/metadoc-js/src/main/scala/monaco/Monaco.scala
@@ -1108,7 +1108,7 @@ package editor {
     def validatePosition(position: IPosition): Position = js.native
     def modifyPosition(position: IPosition, offset: Double): Position = js.native
     def validateRange(range: IRange): Range = js.native
-    def getOffsetAt(position: IPosition): Double = js.native
+    def getOffsetAt(position: IPosition): Int = js.native
     def getPositionAt(offset: Double): Position = js.native
     def getFullModelRange(): Range = js.native
     def isDisposed(): Boolean = js.native
@@ -2279,14 +2279,14 @@ package languages {
     var includeDeclaration: Boolean = js.native
   }
 
-  @js.native
+  @ScalaJSDefined
   trait ReferenceProvider extends js.Object {
     def provideReferences(
         model: editor.IReadOnlyModel,
         position: Position,
         context: ReferenceContext,
         token: CancellationToken
-    ): js.Array[Location] | Thenable[js.Array[Location]] = js.native
+    ): js.Array[Location] | Thenable[js.Array[Location]]
   }
 
   @ScalaJSDefined


### PR DESCRIPTION
Heavily based on the DefinitionProvider.
References #10

<img width="505" alt="screen shot 2017-06-28 at 4 21 29 pm" src="https://user-images.githubusercontent.com/8417/27658490-37d229aa-5c1e-11e7-9c2c-9e1d641500ed.png">
