### PR TITLE
Various cleanups

### DIFF
--- a/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
@@ -7,8 +7,8 @@ import monaco.Range
 import monaco.Promise
 import monaco.editor.Editor
 import monaco.editor.IEditor
+import monaco.services.IResourceInput
 import monaco.services.IEditorService
-import monaco.editor.IResourceInput
 
 @ScalaJSDefined
 class MetadocEditorService extends IEditorService {

--- a/metadoc-js/src/main/scala/metadoc/MetadocTextModelService.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocTextModelService.scala
@@ -16,19 +16,6 @@ import monaco.services.ITextModelResolverService
 
 @ScalaJSDefined
 object MetadocTextModelService extends ITextModelResolverService {
-  // NOTE: we have a private cache here to avoid "duplicate model" errors.
-  // It's possible to hit those errors for example in the reference provider, where
-  // we call `Future.sequence(Seq.map(modelReference))`. Since js is single threaded,
-  // we are safe from race conditions.
-  private val cache = mutable.Map.empty[String, IModel]
-  def createModel(value: String, filename: String): IModel =
-    createModel(value, createUri(filename))
-  def createModel(value: String, uri: Uri): IModel =
-    cache.getOrElseUpdate(
-      uri.path,
-      monaco.editor.Editor.createModel(value, "scala", uri)
-    )
-
   def modelReference(
       filename: String
   ): Future[IReference[ITextEditorModel]] =
@@ -44,7 +31,7 @@ object MetadocTextModelService extends ITextModelResolverService {
       for {
         attrs <- MetadocAttributeService.fetchProtoAttributes(resource.path)
       } yield {
-        val model = createModel(attrs.contents, resource)
+        val model = Editor.createModel(attrs.contents, "scala", resource)
         new ImmortalReference(ITextEditorModel(model))
       }
     }

--- a/metadoc-js/src/main/scala/metadoc/MetadocTextModelService.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocTextModelService.scala
@@ -7,10 +7,10 @@ import scala.meta.internal.semantic.{schema => s}
 import scala.scalajs.js.annotation.ScalaJSDefined
 import monaco.Promise
 import monaco.Uri
-import monaco.common.IReference
-import monaco.common.ImmortalReference
 import monaco.editor.Editor
 import monaco.editor.IModel
+import monaco.services.IReference
+import monaco.services.ImmortalReference
 import monaco.services.ITextEditorModel
 import monaco.services.ITextModelResolverService
 

--- a/metadoc-js/src/main/scala/metadoc/ScalaDefinitionProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaDefinitionProvider.scala
@@ -29,7 +29,7 @@ class ScalaDefinitionProvider(index: Index) extends DefinitionProvider {
             model <- MetadocTextModelService.modelReference(defn.filename)
           } yield {
             val location =
-              resolveLocation(model.`object`.textEditorModel)(defn)
+              model.`object`.textEditorModel.resolveLocation(defn)
             js.Array[Location](location)
           }
         }

--- a/metadoc-js/src/main/scala/metadoc/ScalaDocumentSymbolProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaDocumentSymbolProvider.scala
@@ -34,7 +34,7 @@ class ScalaDocumentSymbolProvider(index: Index)
           name = denotation.name,
           containerName = denotation.info,
           kind = kind,
-          location = resolveLocation(model)(sym.definition.get)
+          location = model.resolveLocation(sym.definition.get)
         )
       }
       js.Array[SymbolInformation](symbols: _*)

--- a/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
@@ -43,7 +43,7 @@ class ScalaReferenceProvider(index: Index) extends ReferenceProvider {
       }
     } yield {
       val locations = references.map {
-        case (referenceModel, pos) => resolveLocation(referenceModel)(pos)
+        case (referenceModel, pos) => referenceModel.resolveLocation(pos)
       }
       js.Array[Location](locations: _*)
     }

--- a/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
@@ -28,24 +28,24 @@ class ScalaReferenceProvider(index: Index) extends ReferenceProvider {
       symbol <- id.fold(Future.successful(Option.empty[d.Symbol]))(
         MetadocAttributeService.fetchSymbol
       )
-      references <- {
-        symbol.fold(Future.successful(Seq.empty[(IModel, d.Position)])) { s =>
-          val references = s.references.map { reference =>
+      locations <- Future.sequence {
+        val references = symbol.map(_.references).getOrElse(Seq.empty)
+        references.groupBy(_.filename).map {
+          case (filename, positions) =>
             // Create the model for each reference. A reference can come from
             // another file, and we need that file's model in order to get
             // correct range selection.
             MetadocTextModelService
-              .modelReference(createUri(reference.filename))
-              .map(_.`object`.textEditorModel -> reference)
-          }
-          Future.sequence(references)
+              .modelReference(createUri(filename))
+              .map { model =>
+                positions.map { pos =>
+                  model.`object`.textEditorModel.resolveLocation(pos)
+                }
+              }
         }
       }
     } yield {
-      val locations = references.map {
-        case (referenceModel, pos) => referenceModel.resolveLocation(pos)
-      }
-      js.Array[Location](locations: _*)
+      js.Array[Location](locations.flatten.toSeq: _*)
     }
   }.toMonacoThenable
 }

--- a/metadoc-js/src/main/scala/metadoc/package.scala
+++ b/metadoc-js/src/main/scala/metadoc/package.scala
@@ -45,17 +45,20 @@ package object metadoc {
       future.toJSPromise.asInstanceOf[Thenable[T]]
   }
 
-  def resolveLocation(model: IReadOnlyModel)(pos: Position): Location = {
-    val startPos = model.getPositionAt(pos.start)
-    val endPos = model.getPositionAt(pos.end)
-    val range = new Range(
-      startPos.lineNumber,
-      startPos.column,
-      endPos.lineNumber,
-      endPos.column
-    )
-    val uri = createUri(pos.filename)
-    val location = new Location(uri, range)
-    location
+  implicit class XtensionIReadOnlyModel(val self: IReadOnlyModel)
+      extends AnyVal {
+    def resolveLocation(pos: Position): Location = {
+      val startPos = self.getPositionAt(pos.start)
+      val endPos = self.getPositionAt(pos.end)
+      val range = new Range(
+        startPos.lineNumber,
+        startPos.column,
+        endPos.lineNumber,
+        endPos.column
+      )
+      val uri = createUri(pos.filename)
+      val location = new Location(uri, range)
+      location
+    }
   }
 }

--- a/metadoc-js/src/main/scala/monaco/Monaco.scala
+++ b/metadoc-js/src/main/scala/monaco/Monaco.scala
@@ -514,50 +514,6 @@ class Token protected () extends js.Object {
 
 package editor {
   @js.native
-  trait ITextEditorOptions extends IEditorOptions {
-    var selection: js.UndefOr[IRange] = js.native
-    var viewState: js.UndefOr[IEditorViewState]
-    var revealInCenterIfOutsideViewport: js.UndefOr[Boolean]
-  }
-
-  @js.native
-  trait IBaseResourceInput extends js.Object {
-    var options: ITextEditorOptions = js.native
-    var label: String = js.native
-    var description: String = js.native
-  }
-
-  @js.native
-  trait IResourceInput extends IBaseResourceInput {
-    var resource: Uri = js.native
-    var encoding: String = js.native
-  }
-
-  @js.native
-  trait IUntitledResourceInput extends IBaseResourceInput {
-    var resource: Uri = js.native
-    var filePath: String = js.native
-    var language: String = js.native
-    var contents: String = js.native
-    var encoding: String = js.native
-  }
-
-  @js.native
-  trait IResourceDiffInput extends IBaseResourceInput {
-    var leftResource: Uri = js.native
-    var rightResource: Uri = js.native
-  }
-
-  @js.native
-  trait IResourceSideBySideInput extends IBaseResourceInput {
-    var masterResource: Uri = js.native
-    var detailResource: Uri = js.native
-  }
-
-  @js.native
-  trait IEditorControl extends js.Object {}
-
-  @js.native
   trait IDiffNavigator extends js.Object {
     var revealFirst: Boolean = js.native
     def canNavigate(): Boolean = js.native
@@ -650,7 +606,6 @@ package editor {
   @ScalaJSDefined
   trait IEditorOverrideServices extends js.Object {
     var editorService: services.IEditorService
-    var textModelService: services.ITextModelService
     var textModelResolverService: services.ITextModelResolverService
   }
 
@@ -2671,18 +2626,4 @@ package worker {
 @js.native
 object Monaco extends js.Object {
   type MarkedString = String | js.Any
-}
-
-package common {
-
-  @ScalaJSDefined
-  trait IReference[T] extends IDisposable {
-    def `object`: T
-  }
-
-  @ScalaJSDefined
-  class ImmortalReference[T](override val `object`: T) extends IReference[T] {
-    override def dispose(): Unit = ()
-  }
-
 }

--- a/metadoc-js/src/main/scala/monaco/MonacoServices.scala
+++ b/metadoc-js/src/main/scala/monaco/MonacoServices.scala
@@ -1,26 +1,78 @@
 package monaco
 
+import scala.scalajs.js
+import scala.scalajs.js.annotation.ScalaJSDefined
+import monaco.editor.{IEditor, IEditorOptions, IEditorViewState, IModel}
+
+/**
+  * Service declarations to hook into the Monaco Editor.
+  *
+  * Out of the box the Monaco Editor uses a simple set of
+  * [[services https://github.com/Microsoft/vscode/blob/a460624f88b4dd3a03d9633e0860c0078c00462f/src/vs/editor/standalone/browser/simpleServices.ts]]
+  * which do not provide the ability out of the box to load content dynamically.
+  *
+  * The default services can be overridden using [[monaco.editor.IEditorOverrideServices]].
+  * The API in inside this package contains the definitions for these services.
+  *
+  * Based on declarations defined in
+  * [[editor.ts https://github.com/Microsoft/vscode/blob/c67ef57cda90b5f28499646f7cc94e8dcc5b0586/src/vs/platform/editor/common/editor.ts]]
+  * and [[resolverService.ts https://github.com/Microsoft/vscode/blob/337ded059ae5140b86caf07e67ce92a41a8e6581/src/vs/editor/common/services/resolverService.ts]].
+  */
 package services {
 
-  import scala.scalajs.js
-  import scala.scalajs.js.annotation.ScalaJSDefined
-  import monaco.common.IReference
-  import monaco.editor.IEditor
-  import monaco.editor.IModel
-  import monaco.editor.IResourceInput
-
   @ScalaJSDefined
-  trait ITextModelContentProvider extends js.Object {
-    def provideTextContent(resource: Uri): Promise[IModel]
+  trait IReference[T] extends IDisposable {
+    def `object`: T
   }
 
   @ScalaJSDefined
-  trait ITextModelService extends js.Object {
-    def registerTextModelContentProvider(
-        scheme: String,
-        provider: ITextModelContentProvider
-    ): IDisposable
+  class ImmortalReference[T](override val `object`: T) extends IReference[T] {
+    override def dispose(): Unit = ()
   }
+
+  @js.native
+  trait ITextEditorOptions extends IEditorOptions {
+    var selection: js.UndefOr[IRange] = js.native
+    var viewState: js.UndefOr[IEditorViewState]
+    var revealInCenterIfOutsideViewport: js.UndefOr[Boolean]
+  }
+
+  @js.native
+  trait IBaseResourceInput extends js.Object {
+    var options: ITextEditorOptions = js.native
+    var label: String = js.native
+    var description: String = js.native
+  }
+
+  @js.native
+  trait IResourceInput extends IBaseResourceInput {
+    var resource: Uri = js.native
+    var encoding: String = js.native
+  }
+
+  @js.native
+  trait IUntitledResourceInput extends IBaseResourceInput {
+    var resource: Uri = js.native
+    var filePath: String = js.native
+    var language: String = js.native
+    var contents: String = js.native
+    var encoding: String = js.native
+  }
+
+  @js.native
+  trait IResourceDiffInput extends IBaseResourceInput {
+    var leftResource: Uri = js.native
+    var rightResource: Uri = js.native
+  }
+
+  @js.native
+  trait IResourceSideBySideInput extends IBaseResourceInput {
+    var masterResource: Uri = js.native
+    var detailResource: Uri = js.native
+  }
+
+  @js.native
+  trait IEditorControl extends js.Object {}
 
   @ScalaJSDefined
   trait IEditorService extends js.Object {
@@ -30,9 +82,13 @@ package services {
     ): Promise[IEditor]
   }
 
-  // NOTE: This service got recently renamed to ITextModelService
-  // see https://github.com/Microsoft/vscode/commit/337ded059ae5140b86caf07e67ce92a41a8e6581
-  // We will need to update correspondingly when upgrading monaco.
+  /**
+    * Service to dynamically load models.
+    *
+    * @note This service was renamed to ITextModelService in
+    * [[https://github.com/Microsoft/vscode/commit/337ded059ae5140b86caf07e67ce92a41a8e6581]]
+    * We will need to update correspondingly when upgrading monaco.
+    */
   @ScalaJSDefined
   trait ITextModelResolverService extends js.Object {
     def createModelReference(


### PR DESCRIPTION
- Adds support for opening selected from from URL (needed for #38)
- Moves all service facades to `monaco.services` with more documentation
- Get rid of the custom model cache by grouping model reference requests by filename (improve on #39)