### PR TITLE
Use proto map for references.

### DIFF
--- a/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
+++ b/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
@@ -44,12 +44,8 @@ object MetadocCli extends CaseApp[MetadocOptions] {
   def metadocPosition(position: Position): d.Position =
     d.Position(
       filename(position.input),
-      Some(
-        d.Range(
-          start = position.start.offset,
-          end = position.end.offset
-        )
-      )
+      position.start.offset,
+      position.end.offset
     )
 
   def getAbsolutePath(path: String): AbsolutePath =

--- a/metadoc-core/src/main/protobuf/metadoc.proto
+++ b/metadoc-core/src/main/protobuf/metadoc.proto
@@ -4,14 +4,23 @@ package metadoc.schema;
 
 message Position {
     string filename = 1;
-    int32 start = 2;
-    int32 end = 3;
+    reserved 2, 3;
+    Range range = 4;
 }
 
 message Symbol {
     string symbol = 1;
     Position definition = 2;
-    repeated Position references = 3;
+    reserved 3;
+    map<string, Ranges> references = 4;
+}
+message Range {
+    int32 start = 2;
+    int32 end = 3;
+}
+
+message Ranges {
+    repeated Range ranges = 1;
 }
 
 message Index {

--- a/metadoc-core/src/main/protobuf/metadoc.proto
+++ b/metadoc-core/src/main/protobuf/metadoc.proto
@@ -4,8 +4,8 @@ package metadoc.schema;
 
 message Position {
     string filename = 1;
-    reserved 2, 3;
-    Range range = 4;
+    int32 start = 2;
+    int32 end = 3;
 }
 
 message Symbol {

--- a/metadoc-core/src/main/scala/metadoc/IndexLookup.scala
+++ b/metadoc-core/src/main/scala/metadoc/IndexLookup.scala
@@ -24,7 +24,7 @@ object IndexLookup {
           .get(filename)
           .toSeq
           .flatMap(
-            _.ranges.map(r => Position(filename, Some(r)))
+            _.ranges.map(r => Position(filename, r.start, r.end))
           ) ++
           definition.filter(_ => includeDeclaration)
     }

--- a/metadoc-core/src/main/scala/metadoc/IndexLookup.scala
+++ b/metadoc-core/src/main/scala/metadoc/IndexLookup.scala
@@ -1,7 +1,7 @@
 package metadoc
 
 import scala.meta.Attributes
-import metadoc.schema.{Index, Position, Symbol}
+import metadoc.schema.{Index, Position, Symbol, Range}
 
 object IndexLookup {
   def findDefinition(
@@ -20,7 +20,12 @@ object IndexLookup {
   ): Seq[Position] =
     findSymbol(offset, attrs, index).toSeq.flatMap {
       case Symbol(_, definition, references) =>
-        references.filter(_.filename == filename) ++
+        references
+          .get(filename)
+          .toSeq
+          .flatMap(
+            _.ranges.map(r => Position(filename, Some(r)))
+          ) ++
           definition.filter(_ => includeDeclaration)
     }
 

--- a/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
@@ -40,7 +40,7 @@ class ScalaReferenceProvider(index: Index) extends ReferenceProvider {
               .map { model =>
                 ranges.ranges.map { range =>
                   model.`object`.textEditorModel.resolveLocation(
-                    schema.Position(filename, Some(range))
+                    schema.Position(filename, range.start, range.end)
                   )
                 }
               }

--- a/metadoc-js/src/main/scala/metadoc/package.scala
+++ b/metadoc-js/src/main/scala/metadoc/package.scala
@@ -48,8 +48,8 @@ package object metadoc {
   implicit class XtensionIReadOnlyModel(val self: IReadOnlyModel)
       extends AnyVal {
     def resolveLocation(pos: Position): Location = {
-      val startPos = self.getPositionAt(pos.range.get.start)
-      val endPos = self.getPositionAt(pos.range.get.end)
+      val startPos = self.getPositionAt(pos.start)
+      val endPos = self.getPositionAt(pos.end)
       val range = new Range(
         startPos.lineNumber,
         startPos.column,

--- a/metadoc-js/src/main/scala/metadoc/package.scala
+++ b/metadoc-js/src/main/scala/metadoc/package.scala
@@ -48,8 +48,8 @@ package object metadoc {
   implicit class XtensionIReadOnlyModel(val self: IReadOnlyModel)
       extends AnyVal {
     def resolveLocation(pos: Position): Location = {
-      val startPos = self.getPositionAt(pos.start)
-      val endPos = self.getPositionAt(pos.end)
+      val startPos = self.getPositionAt(pos.range.get.start)
+      val endPos = self.getPositionAt(pos.range.get.end)
       val range = new Range(
         startPos.lineNumber,
         startPos.column,


### PR DESCRIPTION
This commit changes the schema for references to deduplicate filenames for references coming from the same filename. For some widely used symbols like `Doc`, this this change shrinks the size of the Doc symbol file from 16kb to 4kb.