### PR TITLE
WIP: Use editor service to open initial editor

### DIFF
--- a/metadoc-js/src/main/scala/metadoc/MetadocApp.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocApp.scala
@@ -7,6 +7,7 @@ import scala.meta._
 import scala.scalajs.js
 import scala.scalajs.js.typedarray.TypedArrayBuffer
 import metadoc.schema.Index
+import monaco.Uri
 import monaco.editor.IEditor
 import monaco.editor.IEditorConstructionOptions
 import monaco.editor.IEditorOverrideServices
@@ -44,6 +45,11 @@ object MetadocApp extends js.JSApp {
     input
   }
 
+  def updateLocation(uri: Uri): Unit = {
+    dom.document.getElementById("title").textContent = uri.path
+    dom.window.location.hash = "#/" + uri.path
+  }
+
   def registerLanguageExtensions(index: Index): Unit = {
     monaco.languages.Languages.register(ScalaLanguageExtensionPoint)
     monaco.languages.Languages.setMonarchTokensProvider(
@@ -72,12 +78,9 @@ object MetadocApp extends js.JSApp {
       editorService: MetadocEditorService,
       input: IResourceInput
   ): Unit = {
+    updateLocation(input.resource)
     for (editor <- editorService.open(input)) {
-      editor.onDidChangeModel((event: IModelChangedEvent) => {
-        val path = event.newModelUrl.path
-        dom.document.getElementById("title").textContent = path
-        dom.window.location.hash = "#/" + path
-      })
+      editor.onDidChangeModel(event => updateLocation(event.newModelUrl))
 
       dom.window.onhashchange = { e: Event =>
         openEditor(editorService, parseResourceInput(editor.getModel.uri.path))

--- a/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
@@ -1,5 +1,6 @@
 package metadoc
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.scalajs.js
 import scala.scalajs.js.annotation.ScalaJSDefined
@@ -7,25 +8,55 @@ import monaco.Range
 import monaco.Promise
 import monaco.editor.Editor
 import monaco.editor.IEditor
+import monaco.editor.IEditorConstructionOptions
+import monaco.editor.IEditorOverrideServices
+import monaco.editor.IModelChangedEvent
+import monaco.editor.IStandaloneCodeEditor
 import monaco.services.IResourceInput
 import monaco.services.IEditorService
+import org.scalajs.dom
 
 @ScalaJSDefined
 class MetadocEditorService extends IEditorService {
-  var editor: IEditor = _
+  private lazy val editor: IStandaloneCodeEditor = {
+    val app = dom.document.getElementById("editor")
+    app.innerHTML = ""
+    val options = jsObject[IEditorConstructionOptions]
+    options.readOnly = true
+
+    val overrides = jsObject[IEditorOverrideServices]
+    val editorService = new MetadocEditorService
+    overrides.textModelResolverService = MetadocTextModelService
+    overrides.editorService = this
+
+    val editor = monaco.editor.Editor.create(app, options, overrides)
+    editor.asInstanceOf[js.Dynamic].getControl = { () =>
+      // NOTE: getControl() is defined on SimpleEditor and is called when changing files.
+      editor
+    }
+
+    editor
+  }
+
+  def open(input: IResourceInput): Future[IStandaloneCodeEditor] = {
+    val selection = input.options.selection
+    for {
+      model <- MetadocTextModelService.modelReference(input.resource)
+    } yield {
+      editor.setModel(model.`object`.textEditorModel)
+      selection.foreach {
+        case range: Range =>
+          val pos = range.getStartPosition()
+          editor.setPosition(pos)
+          editor.revealPositionInCenter(pos)
+      }
+      editor
+    }
+  }
+
   override def openEditor(
       input: IResourceInput,
-      sideBySide: js.UndefOr[Boolean]
-  ): Promise[IEditor] = {
-    val selection = input.options.selection
-    val model = Editor.getModel(input.resource)
-    editor.setModel(model)
-    selection.foreach {
-      case range: Range =>
-        val pos = range.getStartPosition()
-        editor.setPosition(pos)
-        editor.revealPositionInCenter(pos)
-    }
-    Future.successful(editor).toMonacoPromise
-  }
+      sideBySide: js.UndefOr[Boolean] = js.undefined
+  ): Promise[IEditor] =
+    open(input).toMonacoPromise
 }

--- a/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
@@ -25,7 +25,6 @@ class MetadocEditorService extends IEditorService {
     options.readOnly = true
 
     val overrides = jsObject[IEditorOverrideServices]
-    val editorService = new MetadocEditorService
     overrides.textModelResolverService = MetadocTextModelService
     overrides.editorService = this
 

--- a/metadoc-js/src/main/scala/monaco/Monaco.scala
+++ b/metadoc-js/src/main/scala/monaco/Monaco.scala
@@ -67,7 +67,7 @@ trait ProgressCallback extends js.Object {
 
 @js.native
 @JSGlobal("monaco.Promise")
-class Promise[V] protected () extends js.Object {
+class Promise[+V] protected () extends js.Object {
   def this(
       init: js.Function3[TValueCallback[V], js.Function1[js.Any, Unit], ProgressCallback, Unit],
       oncancel: js.Any = ???

--- a/metadoc-js/src/main/scala/monaco/MonacoServices.scala
+++ b/metadoc-js/src/main/scala/monaco/MonacoServices.scala
@@ -78,7 +78,7 @@ package services {
   trait IEditorService extends js.Object {
     def openEditor(
         input: IResourceInput,
-        sideBySide: js.UndefOr[Boolean]
+        sideBySide: js.UndefOr[Boolean] = js.undefined
     ): Promise[IEditor]
   }
 


### PR DESCRIPTION
Refactoring to support selections in URLs (#38)

This moves editor creation to the editor service and changes the `main` method to use that.