### PR TITLE
Type alias symbols

### DIFF
--- a/metadoc-js/src/main/scala/metadoc/ScalaDocumentSymbolProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaDocumentSymbolProvider.scala
@@ -60,6 +60,8 @@ class ScalaDocumentSymbolProvider(index: Index)
       Some(SymbolKind.Interface)
     else if (isPackage || isPackageObject)
       Some(SymbolKind.Package)
+    else if (isType)
+      Some(SymbolKind.Namespace) // Note: no type related symbol kind exists
     else
       None
   }

--- a/metadoc-js/src/main/scala/metadoc/ScalaDocumentSymbolProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaDocumentSymbolProvider.scala
@@ -42,21 +42,23 @@ class ScalaDocumentSymbolProvider(index: Index)
   }.toMonacoThenable
 
   def symbolKind(denotation: Denotation): Option[SymbolKind] = {
-    if (denotation.isPARAM || denotation.isTypeParam)
+    import denotation._
+
+    if (isPARAM || isTypeParam)
       None
-    else if (denotation.isVal || denotation.isVar)
+    else if (isVal || isVar)
       Some(SymbolKind.Variable)
-    else if (denotation.isDef)
+    else if (isDef)
       Some(SymbolKind.Function)
-    else if (denotation.isPrimaryCtor || denotation.isSecondaryCtor)
+    else if (isPrimaryCtor || isSecondaryCtor)
       Some(SymbolKind.Constructor)
-    else if (denotation.isClass)
+    else if (isClass)
       Some(SymbolKind.Class)
-    else if (denotation.isObject)
+    else if (isObject)
       Some(SymbolKind.Object)
-    else if (denotation.isTrait)
+    else if (isTrait)
       Some(SymbolKind.Interface)
-    else if (denotation.isPackage || denotation.isPackageObject)
+    else if (isPackage || isPackageObject)
       Some(SymbolKind.Package)
     else
       None


### PR DESCRIPTION
Fix #40 by enabling type aliases in the symbol search.
Lacking a predefined SymbolKind use the one for namespace.

<img width="669" alt="screen shot 2017-07-04 at 12 57 39 am" src="https://user-images.githubusercontent.com/8417/27815750-89a55ac4-6054-11e7-9ad7-31a0ad04ef72.png">
