### PR TITLE
Tweak styles to correctly size the editor

### DIFF
--- a/metadoc-js/src/main/resources/index.html
+++ b/metadoc-js/src/main/resources/index.html
@@ -4,6 +4,8 @@
     <title>Metadoc</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="theme-color" content="#002b36">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <script src="vs/loader.js"></script>
   </head>
   <body>

--- a/metadoc-js/src/main/resources/index.scss
+++ b/metadoc-js/src/main/resources/index.scss
@@ -12,21 +12,24 @@
   font-style: normal;
 }
 
-html, body {
+$header-height: 40px;
+
+body {
   margin: 0;
   width: 100%;
   height: 100%;
   font-family: 'Roboto';
+  overflow: hidden;
 }
 
 header {
   background-color: #002b36;
   color: white;
-  height: 40px;
+  height: $header-height;
   padding: 10px 10px;
 
   #title {
-    line-height: 40px;
+    line-height: $header-height;
     font-size: 16px;
     padding-left: 50px;
     background-image: url('images/favicon.png');
@@ -34,22 +37,20 @@ header {
     background-size: contain;
     display: block;
     font-weight: bold;
+
+    // Show partial path as: ".../org/example/Module.scala"
+    text-overflow: ellipsis;
+    direction: rtl;
+    text-align: left;
+    overflow: hidden;
+    white-space: nowrap;
   }
 }
 
 main {
-  // FIXME:
-  position: relative;
-  min-height: 90vh;
-}
-
-#editor {
-	position: absolute;
-	left: 0;
-	top: 0;
-	width: 100%;
-	height: 100%;
-	margin: 0;
-	padding: 0;
-	overflow: hidden;
+  #editor {
+    // Header height + padding-{top,bottom} = 40px + 2 * 10px
+    height: calc(100vh - 60px);
+    margin: 0;
+  }
 }

--- a/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
@@ -23,6 +23,7 @@ class MetadocEditorService extends IEditorService {
     app.innerHTML = ""
     val options = jsObject[IEditorConstructionOptions]
     options.readOnly = true
+    options.scrollBeyondLastLine = false
 
     val overrides = jsObject[IEditorOverrideServices]
     overrides.textModelService = MetadocTextModelService

--- a/metadoc-js/webpack.config.js
+++ b/metadoc-js/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = merge(config, {
         })
       },
       {
-        test: /\.scss$/,
+        test: /\.s?css$/,
         use: ExtractSass.extract({
           use: [
             { loader: "css-loader" }, // translates CSS into CommonJS


### PR DESCRIPTION
Maximizes the editor element to fill the whole available space under the
header. Also disables `scrollBeyondLastLine` since this doesn't make
sense in read-only mode.

---

I accidentally published this to scalameta.org/metadoc, so this can be viewed in action there.