### PR TITLE
Update to Scala.js 0.6.20

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,7 @@ lazy val js = project
     moduleName := "metadoc-js",
     additionalNpmConfig in Compile := Map("private" -> bool(true)),
     additionalNpmConfig in Test := additionalNpmConfig.in(Test).value,
+    scalacOptions += "-P:scalajs:sjsDefinedByDefault",
     scalaJSUseMainModuleInitializer := true,
     version in webpack := "2.6.1",
     version in installWebpackDevServer := "2.2.0",

--- a/metadoc-js/src/main/scala/metadoc/MetadocApp.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocApp.scala
@@ -13,8 +13,8 @@ import monaco.services.{IResourceInput, ITextEditorOptions}
 import org.scalajs.dom
 import org.scalajs.dom.Event
 
-object MetadocApp extends js.JSApp {
-  def main(): Unit = {
+object MetadocApp {
+  def main(args: Array[String]): Unit = {
     for {
       _ <- loadMonaco()
       indexBytes <- fetchBytes("metadoc.index")

--- a/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
@@ -3,7 +3,6 @@ package metadoc
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.scalajs.js
-import scala.scalajs.js.annotation.ScalaJSDefined
 import monaco.Range
 import monaco.Promise
 import monaco.editor.IEditor
@@ -14,7 +13,6 @@ import monaco.services.IResourceInput
 import monaco.services.IEditorService
 import org.scalajs.dom
 
-@ScalaJSDefined
 class MetadocEditorService extends IEditorService {
   private lazy val editor: IStandaloneCodeEditor = {
     val app = dom.document.getElementById("editor")

--- a/metadoc-js/src/main/scala/metadoc/MetadocTextModelService.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocTextModelService.scala
@@ -2,7 +2,6 @@ package metadoc
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.scalajs.js.annotation.ScalaJSDefined
 import monaco.Promise
 import monaco.Uri
 import monaco.editor.Editor
@@ -11,7 +10,6 @@ import monaco.services.ITextEditorModel
 import monaco.services.ITextModelService
 import monaco.services.ImmortalReference
 
-@ScalaJSDefined
 object MetadocTextModelService extends ITextModelService {
   def modelReference(
       filename: String

--- a/metadoc-js/src/main/scala/metadoc/ScalaDefinitionProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaDefinitionProvider.scala
@@ -4,7 +4,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import org.langmeta._
 import scala.scalajs.js
-import scala.scalajs.js.annotation._
 import metadoc.schema.Index
 import monaco.editor.IReadOnlyModel
 import monaco.languages.DefinitionProvider
@@ -12,7 +11,6 @@ import monaco.languages.Location
 import monaco.CancellationToken
 import monaco.Position
 
-@ScalaJSDefined
 class ScalaDefinitionProvider(index: Index) extends DefinitionProvider {
   override def provideDefinition(
       model: IReadOnlyModel,

--- a/metadoc-js/src/main/scala/metadoc/ScalaDocumentSymbolProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaDocumentSymbolProvider.scala
@@ -2,7 +2,6 @@ package metadoc
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.scalajs.js
-import scala.scalajs.js.annotation._
 import metadoc.schema.Index
 import monaco.CancellationToken
 import monaco.editor.IReadOnlyModel
@@ -13,7 +12,6 @@ import org.langmeta.Denotation
 import org.langmeta.semanticdb.ResolvedSymbol
 import org.{langmeta => m}
 
-@ScalaJSDefined
 class ScalaDocumentSymbolProvider(index: Index)
     extends DocumentSymbolProvider {
   override def provideDocumentSymbols(

--- a/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
@@ -3,7 +3,6 @@ package metadoc
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.scalajs.js
-import scala.scalajs.js.annotation._
 import org.langmeta.Document
 import metadoc.schema.Index
 import monaco.{CancellationToken, Position}
@@ -12,7 +11,6 @@ import monaco.languages.{Location, ReferenceContext, ReferenceProvider}
 import metadoc.{schema => d}
 import monaco.editor.IModel
 
-@ScalaJSDefined
 class ScalaReferenceProvider(index: Index) extends ReferenceProvider {
   override def provideReferences(
       model: IReadOnlyModel,

--- a/metadoc-js/src/main/scala/monaco/Monaco.scala
+++ b/metadoc-js/src/main/scala/monaco/Monaco.scala
@@ -29,7 +29,6 @@ trait Thenable[T] extends js.Object {
  */
 }
 
-@ScalaJSDefined
 trait IDisposable extends js.Object {
   def dispose(): Unit
 }
@@ -659,7 +658,6 @@ package editor {
     def get(): T = js.native
   }
 
-  @ScalaJSDefined
   trait IEditorOverrideServices extends js.Object {
     var editorService: services.IEditorService
     var textModelService: services.ITextModelService
@@ -2284,7 +2282,6 @@ package languages {
     var includeDeclaration: Boolean = js.native
   }
 
-  @ScalaJSDefined
   trait ReferenceProvider extends js.Object {
     def provideReferences(
         model: editor.IReadOnlyModel,
@@ -2294,10 +2291,8 @@ package languages {
     ): Thenable[js.Array[Location]]
   }
 
-  @ScalaJSDefined
   class Location(val uri: Uri, val range: IRange) extends js.Object
 
-  @ScalaJSDefined
   trait DefinitionProvider extends js.Object {
     def provideDefinition(
         model: editor.IReadOnlyModel,
@@ -2360,7 +2355,6 @@ package languages {
     def apply(value: SymbolKind): String = js.native
   }
 
-  @ScalaJSDefined
   class SymbolInformation(
       val name: String,
       val containerName: String,
@@ -2368,7 +2362,6 @@ package languages {
       val location: Location
   ) extends js.Object
 
-  @ScalaJSDefined
   trait DocumentSymbolProvider extends js.Object {
     def provideDocumentSymbols(
         model: editor.IReadOnlyModel,
@@ -2489,7 +2482,6 @@ package languages {
     ): ICodeLensSymbol | Thenable[ICodeLensSymbol] = js.native
   }
 
-  @ScalaJSDefined
   class ILanguageExtensionPoint(
       val id: String,
       val extensions: js.UndefOr[js.Array[String]] = js.undefined,

--- a/metadoc-js/src/main/scala/monaco/MonacoServices.scala
+++ b/metadoc-js/src/main/scala/monaco/MonacoServices.scala
@@ -1,7 +1,6 @@
 package monaco
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.ScalaJSDefined
 import monaco.editor.{IEditor, IEditorOptions, IModel}
 import monaco.editor.Editor.IEditorViewState
 
@@ -21,12 +20,10 @@ import monaco.editor.Editor.IEditorViewState
   */
 package services {
 
-  @ScalaJSDefined
   trait IReference[T] extends IDisposable {
     def `object`: T
   }
 
-  @ScalaJSDefined
   class ImmortalReference[T](override val `object`: T) extends IReference[T] {
     override def dispose(): Unit = ()
   }
@@ -75,7 +72,6 @@ package services {
   @js.native
   trait IEditorControl extends js.Object {}
 
-  @ScalaJSDefined
   trait IEditorService extends js.Object {
     def openEditor(
         input: IResourceInput,
@@ -86,14 +82,12 @@ package services {
   /**
     * Service to dynamically load models.
     */
-  @ScalaJSDefined
   trait ITextModelService extends js.Object {
     def createModelReference(
         resource: Uri
     ): Promise[IReference[ITextEditorModel]]
   }
 
-  @ScalaJSDefined
   trait ITextEditorModel extends js.Object {
     def textEditorModel: IModel
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.7.0")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC6")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")


### PR DESCRIPTION
Removes @ScalaJSDefined in favour of compiler flag and allows to use
sbt discovered main class and method instead of JSApp.