### PR TITLE
Package webpack assets and place inside the CLI JAR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,16 @@ lazy val cli = project
     libraryDependencies ++= List(
       "com.github.alexarchambault" %% "case-app" % "1.2.0-M3",
       "com.github.pathikrit" %% "better-files" % "3.0.0"
-    )
+    ),
+    resourceGenerators in Compile += Def.task {
+      val zip = (resourceManaged in Compile).value / "metadoc-assets.zip"
+      val _ = (webpack in (js, Compile, fullOptJS)).value
+      val assetsDirectory = (target in js).value / "app"
+      val paths: PathFinder = (assetsDirectory.*** --- assetsDirectory)
+      val mappings = paths.get pair relativeTo(assetsDirectory)
+      IO.zip(mappings, zip)
+      Seq(zip)
+    }.taskValue
   )
   .dependsOn(coreJVM)
 


### PR DESCRIPTION
Adds a resource generator which generates a metadoc-assets.zip file
based on fullOptJS so the CLI can easily locate it on its classpath and
extract the content when generating a site.

![screen shot 2017-09-14 at 2 41 02 pm](https://user-images.githubusercontent.com/8417/30449496-f25a4fd8-995d-11e7-8e84-3fa258957da0.png)
