### PR TITLE
Merge the symbol information of case classes and their synthetic objects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "paiges"]
 	path = paiges
-	url = https://github.com/ChocPanda/paiges.git
+	url = https://github.com/typelevel/paiges.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "paiges"]
 	path = paiges
-	url = https://github.com/typelevel/paiges.git
+	url = https://github.com/ChocPanda/paiges.git

--- a/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
+++ b/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
@@ -209,8 +209,7 @@ class CliRunner(classpath: Seq[AbsolutePath], options: MetadocOptions) {
           tick()
           val symbolIndex = ref.get()
           val actualIndex = symbolIndex.definition match {
-            case Some(_) if symbolIndex.references.isEmpty => updateReferencesForType(symbolsMap, symbolIndex)
-            case Some(_) => symbolIndex
+            case Some(_) => updateReferencesForType(symbolsMap, symbolIndex)
             case None => updateDefinitionsForTerm(symbolsMap, symbolIndex)
           }
 

--- a/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
+++ b/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
@@ -41,20 +41,20 @@ import org.langmeta.internal.semanticdb.{schema => s}
 @AppVersion("0.1.0-SNAPSHOT")
 @ProgName("metadoc")
 case class MetadocOptions(
-                           @HelpMessage("The output directory to generate the metadoc site.")
-                           target: Option[String] = None,
-                           @HelpMessage(
-                             "Clean the target directory before generating new site. " +
-                               "All files will be deleted so be careful."
-                           )
-                           cleanTargetFirst: Boolean = false,
-                           @HelpMessage(
-                             "Experimental. Emit metadoc.zip file instead of static files."
-                           )
-                           zip: Boolean = false,
-                           @HelpMessage("Disable fancy progress bar")
-                           nonInteractive: Boolean = false
-                         )
+    @HelpMessage("The output directory to generate the metadoc site.")
+    target: Option[String] = None,
+    @HelpMessage(
+      "Clean the target directory before generating new site. " +
+        "All files will be deleted so be careful."
+    )
+    cleanTargetFirst: Boolean = false,
+    @HelpMessage(
+      "Experimental. Emit metadoc.zip file instead of static files."
+    )
+    zip: Boolean = false,
+    @HelpMessage("Disable fancy progress bar")
+    nonInteractive: Boolean = false
+)
 
 case class Target(target: AbsolutePath, onClose: () => Unit)
 
@@ -86,7 +86,9 @@ class CliRunner(classpath: Seq[AbsolutePath], options: MetadocOptions) {
   private val filenames = new ConcurrentSkipListSet[String]()
   private val symbols =
     new ConcurrentHashMap[Symbol, AtomicReference[d.SymbolIndex]]()
-  private val mappingFunction: JFunction[Symbol, AtomicReference[d.SymbolIndex]] =
+  private val mappingFunction: JFunction[Symbol, AtomicReference[
+    d.SymbolIndex
+  ]] =
     t => new AtomicReference(d.SymbolIndex(symbol = t))
 
   private def overwrite(out: Path, bytes: Array[Byte]): Unit = {
@@ -110,10 +112,10 @@ class CliRunner(classpath: Seq[AbsolutePath], options: MetadocOptions) {
   }
 
   private def addReference(
-                            filename: String,
-                            range: d.Range,
-                            symbol: Symbol
-                          ): Unit = {
+      filename: String,
+      range: d.Range,
+      symbol: Symbol
+  ): Unit = {
     val value = symbols.computeIfAbsent(symbol, mappingFunction)
     value.getAndUpdate(new UnaryOperator[d.SymbolIndex] {
       override def apply(t: d.SymbolIndex): d.SymbolIndex = {
@@ -144,9 +146,9 @@ class CliRunner(classpath: Seq[AbsolutePath], options: MetadocOptions) {
       val files = ParArray.newBuilder[AbsolutePath]
       val visitor = new SimpleFileVisitor[Path] {
         override def visitFile(
-                                file: Path,
-                                attrs: BasicFileAttributes
-                              ): FileVisitResult = {
+            file: Path,
+            attrs: BasicFileAttributes
+        ): FileVisitResult = {
           if (file.getFileName.toString.endsWith(".semanticdb")) {
             files += AbsolutePath(file)
           }
@@ -170,7 +172,7 @@ class CliRunner(classpath: Seq[AbsolutePath], options: MetadocOptions) {
           db.documents.foreach { document =>
             document.names.foreach {
               case s.ResolvedName(_, sym, _)
-                if !sym.endsWith(".") && !sym.endsWith("#") =>
+                  if !sym.endsWith(".") && !sym.endsWith("#") =>
               // Do nothing, local symbol.
               case s.ResolvedName(Some(s.Position(start, end)), sym, true) =>
                 addDefinition(sym, d.Position(document.filename, start, end))
@@ -221,24 +223,37 @@ class CliRunner(classpath: Seq[AbsolutePath], options: MetadocOptions) {
       }
     }
 
-  private def updateReferencesForType(symbolsMap: concurrent.Map[Symbol, AtomicReference[SymbolIndex]], symbolIndex: SymbolIndex) = {
+  private def updateReferencesForType(
+      symbolsMap: concurrent.Map[Symbol, AtomicReference[SymbolIndex]],
+      symbolIndex: SymbolIndex
+  ) = {
     Symbol(symbolIndex.symbol) match {
       case Symbol.Global(owner, Signature.Type(name)) =>
         (for {
-          syntheticObjRef <- symbolsMap.get(Symbol.Global(owner, Signature.Term(name)).syntax)
+          syntheticObjRef <- symbolsMap.get(
+            Symbol.Global(owner, Signature.Term(name)).syntax
+          )
           if syntheticObjRef.get().definition.isEmpty
-        } yield symbolIndex.copy(references = syntheticObjRef.get().references)).getOrElse(symbolIndex)
+        } yield
+          symbolIndex.copy(references = syntheticObjRef.get().references))
+          .getOrElse(symbolIndex)
       case _ => symbolIndex
     }
   }
 
-  private def updateDefinitionsForTerm(symbolsMap: concurrent.Map[Symbol, AtomicReference[SymbolIndex]], symbolIndex: SymbolIndex) = {
+  private def updateDefinitionsForTerm(
+      symbolsMap: concurrent.Map[Symbol, AtomicReference[SymbolIndex]],
+      symbolIndex: SymbolIndex
+  ) = {
     Symbol(symbolIndex.symbol) match {
       case Symbol.Global(owner, Signature.Term(name)) =>
         (for {
-          typeRef <- symbolsMap.get(Symbol.Global(owner, Signature.Type(name)).syntax)
+          typeRef <- symbolsMap.get(
+            Symbol.Global(owner, Signature.Type(name)).syntax
+          )
           definition <- typeRef.get().definition
-        } yield symbolIndex.copy(definition = Some(definition))).getOrElse(symbolIndex)
+        } yield symbolIndex.copy(definition = Some(definition)))
+          .getOrElse(symbolIndex)
       case _ => symbolIndex
     }
   }

--- a/metadoc-core/src/main/protobuf/metadoc.proto
+++ b/metadoc-core/src/main/protobuf/metadoc.proto
@@ -8,7 +8,7 @@ message Position {
     int32 end = 3;
 }
 
-message Symbol {
+message SymbolIndex {
     string symbol = 1;
     Position definition = 2;
     reserved 3;

--- a/metadoc-core/src/main/scala/metadoc/MetadocSemanticdbIndex.scala
+++ b/metadoc-core/src/main/scala/metadoc/MetadocSemanticdbIndex.scala
@@ -8,7 +8,7 @@ import org.langmeta.internal.semanticdb.{schema => s}
 /** Index to lookup symbol definitions and references. */
 trait MetadocSemanticdbIndex {
   def document: s.Document
-  def symbol(sym: String): Future[Option[d.Symbol]]
+  def symbol(sym: String): Future[Option[d.SymbolIndex]]
   def semanticdb(sym: String): Future[Option[s.Document]]
   def dispatch(event: MetadocEvent): Unit
 
@@ -27,8 +27,8 @@ trait MetadocSemanticdbIndex {
     }
   }
 
-  def fetchSymbol(offset: Int): Future[Option[d.Symbol]] =
-    resolve(offset).fold(Future.successful(Option.empty[d.Symbol])) {
+  def fetchSymbol(offset: Int): Future[Option[d.SymbolIndex]] =
+    resolve(offset).fold(Future.successful(Option.empty[d.SymbolIndex])) {
       case s.ResolvedName(_, sym, _) =>
         m.Symbol(sym) match {
           case m.Symbol.Global(_, _) =>
@@ -52,7 +52,7 @@ trait MetadocSemanticdbIndex {
                 }
               )
             )
-            val dsymbol = d.Symbol(sym, definition, references)
+            val dsymbol = d.SymbolIndex(sym, definition, references)
             Future.successful(Some(dsymbol))
         }
     }

--- a/metadoc-js/src/main/scala/metadoc/MetadocFetch.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocFetch.scala
@@ -8,12 +8,12 @@ import metadoc.{schema => d}
 
 object MetadocFetch {
 
-  def symbol(symbolId: String): Future[Option[d.Symbol]] = {
+  def symbol(symbolId: String): Future[Option[d.SymbolIndex]] = {
     val url = "symbol/" + JSSha512.sha512(symbolId)
     for {
       bytes <- fetchBytes(url)
     } yield {
-      Some(d.Symbol.parseFrom(bytes))
+      Some(d.SymbolIndex.parseFrom(bytes))
     }
   }.recover(or404)
 

--- a/metadoc-js/src/main/scala/metadoc/MutableBrowserIndex.scala
+++ b/metadoc-js/src/main/scala/metadoc/MutableBrowserIndex.scala
@@ -12,7 +12,7 @@ class MutableBrowserIndex(init: MetadocState) extends MetadocSemanticdbIndex {
       state = state.copy(document = document)
   }
   override def document: Document = state.document
-  override def symbol(sym: String): Future[Option[schema.Symbol]] =
+  override def symbol(sym: String): Future[Option[schema.SymbolIndex]] =
     MetadocFetch.symbol(sym)
   override def semanticdb(sym: String): Future[Option[s.Document]] =
     MetadocFetch.document(sym)

--- a/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
@@ -263,8 +263,8 @@ class MetadocCliTest
   }
 
   checkSymbolIndex(
-      "_root_.org.typelevel.paiges.Json.JArray.",
-      """
+    "_root_.org.typelevel.paiges.Json.JArray.",
+    """
         |symbol: "_root_.org.typelevel.paiges.Json.JArray."
         |definition {
         |  filename: "paiges/core/src/test/scala/org/typelevel/paiges/JsonTest.scala"
@@ -285,7 +285,7 @@ class MetadocCliTest
         |  }
         |}
       """.stripMargin
-    )
+  )
 
   checkSymbolIndex(
     "_root_.org.typelevel.paiges.Json.JArray#",

--- a/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
@@ -51,7 +51,7 @@ class MetadocCliTest
     val obtained = FileIO
       .listAllFilesRecursively(out.resolve("symbol"))
       .map { path =>
-        val sym = d.Symbol.parseFrom(path.readAllBytes)
+        val sym = d.SymbolIndex.parseFrom(path.readAllBytes)
         assert(sym.definition.isDefined)
         sym.symbol
       }

--- a/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
@@ -58,8 +58,7 @@ class MetadocCliTest
       .sorted
       .mkString("\n")
     val expected =
-      """|
-         |_root_.org.typelevel.paiges.Chunk.
+      """|_root_.org.typelevel.paiges.Chunk.
          |_root_.org.typelevel.paiges.Chunk.best(ILorg/typelevel/paiges/Doc;)Lscala/collection/Iterator;.
          |_root_.org.typelevel.paiges.Chunk.indentMax.
          |_root_.org.typelevel.paiges.Chunk.indentTable.
@@ -105,19 +104,25 @@ class MetadocCliTest
          |_root_.org.typelevel.paiges.Doc.
          |_root_.org.typelevel.paiges.Doc.Align#
          |_root_.org.typelevel.paiges.Doc.Align#`<init>`(Lorg/typelevel/paiges/Doc;)V.
+         |_root_.org.typelevel.paiges.Doc.Align.
          |_root_.org.typelevel.paiges.Doc.Concat#
          |_root_.org.typelevel.paiges.Doc.Concat#`<init>`(Lorg/typelevel/paiges/Doc;Lorg/typelevel/paiges/Doc;)V.
+         |_root_.org.typelevel.paiges.Doc.Concat.
          |_root_.org.typelevel.paiges.Doc.Empty.
          |_root_.org.typelevel.paiges.Doc.Line#
          |_root_.org.typelevel.paiges.Doc.Line#`<init>`(Z)V.
          |_root_.org.typelevel.paiges.Doc.Line#asFlatDoc()Lorg/typelevel/paiges/Doc;.
+         |_root_.org.typelevel.paiges.Doc.Line.
          |_root_.org.typelevel.paiges.Doc.Nest#
          |_root_.org.typelevel.paiges.Doc.Nest#`<init>`(ILorg/typelevel/paiges/Doc;)V.
+         |_root_.org.typelevel.paiges.Doc.Nest.
          |_root_.org.typelevel.paiges.Doc.Text#
          |_root_.org.typelevel.paiges.Doc.Text#`<init>`(Ljava/lang/String;)V.
+         |_root_.org.typelevel.paiges.Doc.Text.
          |_root_.org.typelevel.paiges.Doc.Union#
          |_root_.org.typelevel.paiges.Doc.Union#`<init>`(Lorg/typelevel/paiges/Doc;Lscala/Function0;)V.
          |_root_.org.typelevel.paiges.Doc.Union#bDoc.
+         |_root_.org.typelevel.paiges.Doc.Union.
          |_root_.org.typelevel.paiges.Doc.cat(Lscala/collection/Iterable;)Lorg/typelevel/paiges/Doc;.
          |_root_.org.typelevel.paiges.Doc.char(C)Lorg/typelevel/paiges/Doc;.
          |_root_.org.typelevel.paiges.Doc.charTable.
@@ -196,6 +201,7 @@ class MetadocCliTest
          |_root_.org.typelevel.paiges.Json.JArray#
          |_root_.org.typelevel.paiges.Json.JArray#`<init>`(Lscala/collection/immutable/Vector;)V.
          |_root_.org.typelevel.paiges.Json.JArray#toDoc()Lorg/typelevel/paiges/Doc;.
+         |_root_.org.typelevel.paiges.Json.JArray.
          |_root_.org.typelevel.paiges.Json.JBool#
          |_root_.org.typelevel.paiges.Json.JBool#`<init>`(Z)V.
          |_root_.org.typelevel.paiges.Json.JBool#toDoc()Lorg/typelevel/paiges/Doc;.
@@ -204,12 +210,14 @@ class MetadocCliTest
          |_root_.org.typelevel.paiges.Json.JNumber#
          |_root_.org.typelevel.paiges.Json.JNumber#`<init>`(D)V.
          |_root_.org.typelevel.paiges.Json.JNumber#toDoc()Lorg/typelevel/paiges/Doc;.
+         |_root_.org.typelevel.paiges.Json.JNumber.
          |_root_.org.typelevel.paiges.Json.JObject#
          |_root_.org.typelevel.paiges.Json.JObject#`<init>`(Lscala/collection/immutable/Map;)V.
          |_root_.org.typelevel.paiges.Json.JObject#toDoc()Lorg/typelevel/paiges/Doc;.
          |_root_.org.typelevel.paiges.Json.JString#
          |_root_.org.typelevel.paiges.Json.JString#`<init>`(Ljava/lang/String;)V.
          |_root_.org.typelevel.paiges.Json.JString#toDoc()Lorg/typelevel/paiges/Doc;.
+         |_root_.org.typelevel.paiges.Json.JString.
          |_root_.org.typelevel.paiges.Json.escape(Ljava/lang/String;)Ljava/lang/String;.
          |_root_.org.typelevel.paiges.JsonTest#
          |_root_.org.typelevel.paiges.JsonTest#`<init>`()V.
@@ -226,6 +234,7 @@ class MetadocCliTest
          |_root_.org.typelevel.paiges.package.call(Ljava/lang/Object;Lscala/collection/immutable/List;)Ljava/lang/Object;.
          |_root_.org.typelevel.paiges.package.call(Ljava/lang/Object;Lscala/collection/immutable/List;)Ljava/lang/Object;.A#
       """.stripMargin
+
     assertNoDiff(obtained, expected)
   }
 

--- a/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
@@ -248,4 +248,67 @@ class MetadocCliTest
     }
   }
 
+  def checkSymbolIndex(id: String, expected: String) = {
+    test(id) {
+      val index = d.SymbolIndex.parseFrom(
+        out
+          .resolve("symbol")
+          .resolve(MetadocCli.encodeSymbolName(id))
+          .readAllBytes
+      )
+      val obtained = index.toString
+      println(obtained)
+      assertNoDiff(obtained, expected)
+    }
+  }
+
+  checkSymbolIndex(
+      "_root_.org.typelevel.paiges.Json.JArray.",
+      """
+        |symbol: "_root_.org.typelevel.paiges.Json.JArray."
+        |definition {
+        |  filename: "paiges/core/src/test/scala/org/typelevel/paiges/JsonTest.scala"
+        |  start: 711
+        |  end: 717
+        |}
+        |references {
+        |  key: "paiges/core/src/test/scala/org/typelevel/paiges/JsonTest.scala"
+        |  value {
+        |    ranges {
+        |      start: 1421
+        |      end: 1427
+        |    }
+        |    ranges {
+        |      start: 1345
+        |      end: 1351
+        |    }
+        |  }
+        |}
+      """.stripMargin
+    )
+
+  checkSymbolIndex(
+    "_root_.org.typelevel.paiges.Json.JArray#",
+    """
+      |symbol: "_root_.org.typelevel.paiges.Json.JArray#"
+      |definition {
+      |  filename: "paiges/core/src/test/scala/org/typelevel/paiges/JsonTest.scala"
+      |  start: 711
+      |  end: 717
+      |}
+      |references {
+      |  key: "paiges/core/src/test/scala/org/typelevel/paiges/JsonTest.scala"
+      |  value {
+      |    ranges {
+      |      start: 1421
+      |      end: 1427
+      |    }
+      |    ranges {
+      |      start: 1345
+      |      end: 1351
+      |    }
+      |  }
+      |}
+      |""".stripMargin
+  )
 }


### PR DESCRIPTION
Add a post process step in the Cli to add references to the case class type from the synthetic object and add the case class definition to the synthetic object symbol.

I have also renamed symbol to symbol index