### PR TITLE
Move navigation management to separate module

### DIFF
--- a/metadoc-js/src/main/scala/metadoc/Navigation.scala
+++ b/metadoc-js/src/main/scala/metadoc/Navigation.scala
@@ -1,0 +1,83 @@
+package metadoc
+
+import scala.util.Try
+import scala.scalajs.js
+import org.scalajs.dom
+import java.net.URI
+import monaco.Range
+
+object Navigation {
+  class State(val path: String, val selection: Option[Selection]) extends js.Object {
+    override def toString: String =
+      path + selection.map(_.toString).fold("")("#" + _)
+  }
+
+  case class Selection(
+      startLine: Int,
+      startColumn: Int,
+      endLine: Int,
+      endColumn: Int
+  ) {
+    def toRange() =
+      new Range(startLine, startColumn, endLine, endColumn)
+
+    override def toString: String = {
+      def position(lineNumber: Int, column: Int): String =
+        s"L$lineNumber${if (column > 1) s"C${column}" else ""}"
+
+      val start = position(startLine, startColumn)
+      if (startLine == endLine && startColumn == endColumn)
+        start
+      else if (startLine == endLine - 1 && startColumn == 1 && endColumn == 1)
+        start
+      else
+        start + "-" + position(endLine, endColumn)
+    }
+  }
+
+  object Selection {
+    val Regex = """L(\d+)(C(\d+))?(-L(\d+)(C(\d+))?)?""".r
+
+    def fromRange(range: Range): Selection =
+      new Selection(
+        range.startLineNumber.toInt,
+        range.startColumn.toInt,
+        range.endLineNumber.toInt,
+        range.endColumn.toInt
+      )
+  }
+
+  def currentState(
+    state: Option[State] = Option(dom.window.history.state.asInstanceOf[Navigation.State]),
+    locationHash: => String = dom.window.location.hash.dropWhile(_ == '#')
+  ): Option[Navigation.State] =
+    state.orElse(parseState(locationHash))
+
+  def parseState(state: String): Option[Navigation.State] = {
+    for (uri <- parseUri(state)) yield {
+      val selection = Option(uri.getFragment).flatMap(parseSelection)
+      new State(uri.getPath, selection)
+    }
+  }
+
+  def parseUri(uri: String): Option[URI] =
+    if (uri.isEmpty) None
+    else Try(URI.create(uri)).toOption
+
+  def parseSelection(selection: String): Option[Selection] = {
+    selection match {
+      case Selection.Regex(fromLine, _, fromCol, _, toLine, _, toCol) =>
+        Some(
+          new Selection(
+            fromLine.toInt,
+            Option(fromCol).map(_.toInt).getOrElse(1),
+            Option(toLine).map(_.toInt).getOrElse(fromLine.toInt + 1),
+            Option(toCol).map(_.toInt).getOrElse(1)
+          )
+        )
+      case _ =>
+        None
+    }
+  }
+
+}

--- a/metadoc-js/src/main/scala/metadoc/Navigation.scala
+++ b/metadoc-js/src/main/scala/metadoc/Navigation.scala
@@ -7,7 +7,8 @@ import java.net.URI
 import monaco.Range
 
 object Navigation {
-  class State(val path: String, val selection: Option[Selection]) extends js.Object {
+  class State(val path: String, val selection: Option[Selection])
+      extends js.Object {
     override def toString: String =
       path + selection.map(_.toString).fold("")("#" + _)
   }
@@ -48,8 +49,10 @@ object Navigation {
   }
 
   def currentState(
-    state: Option[State] = Option(dom.window.history.state.asInstanceOf[Navigation.State]),
-    locationHash: => String = dom.window.location.hash.dropWhile(_ == '#')
+      state: Option[State] = Option(
+        dom.window.history.state.asInstanceOf[Navigation.State]
+      ),
+      locationHash: => String = dom.window.location.hash.dropWhile(_ == '#')
   ): Option[Navigation.State] =
     state.orElse(parseState(locationHash))
 

--- a/metadoc-js/src/main/scala/metadoc/package.scala
+++ b/metadoc-js/src/main/scala/metadoc/package.scala
@@ -38,14 +38,6 @@ package object metadoc {
   def createUri(filename: String): Uri =
     Uri.parse(s"semanticdb:$filename")
 
-  def createInputResource(uri: Uri, selection: Option[Range]): IResourceInput = {
-    val input = jsObject[IResourceInput]
-    input.resource = createUri(uri.path)
-    input.options = jsObject[ITextEditorOptions]
-    input.options.selection = selection.orUndefined
-    input
-  }
-
   implicit class XtensionFutureToThenable[T](future: Future[T]) {
     import scala.scalajs.js.JSConverters._
     // This method allows us to work with Future[T] in metadoc and convert

--- a/metadoc-js/src/test/scala/metadoc/NavigationTest.scala
+++ b/metadoc-js/src/test/scala/metadoc/NavigationTest.scala
@@ -1,0 +1,83 @@
+package metadoc
+
+import org.scalatest.FunSuite
+import monaco.Range
+
+class NavigationTest extends FunSuite {
+  test("Navigation.parseState") {
+    val state = Navigation.currentState(None, "/path")
+    assert(state.isDefined)
+    assert(state.get.path == "/path")
+    assert(state.get.selection.isEmpty)
+
+    val stateWithSelection = Navigation.parseState("/path2#L11")
+    assert(stateWithSelection.isDefined)
+    assert(stateWithSelection.get.path == "/path2")
+    assert(stateWithSelection.get.selection == Some(Navigation.Selection(11, 1, 12, 1)))
+
+    assert(Navigation.parseState("").isEmpty)
+    assert(Navigation.parseState("#/path2#L11").isEmpty)
+  }
+
+  test("Navigation.curentState") {
+    val stateFromHash = Navigation.currentState(None, "/path")
+    assert(stateFromHash.isDefined)
+    assert(stateFromHash.get.path == "/path")
+    assert(stateFromHash.get.selection.isEmpty)
+
+    val stateFromHashWithSelection = Navigation.currentState(None, "/path2#L11")
+    assert(stateFromHashWithSelection.isDefined)
+    assert(stateFromHashWithSelection.get.path == "/path2")
+    assert(stateFromHashWithSelection.get.selection == Some(Navigation.Selection(11, 1, 12, 1)))
+
+    val stateFromHistory = Navigation.currentState(stateFromHash, "/other-path")
+    assert(stateFromHistory.isDefined)
+    assert(stateFromHistory.get.path == "/path")
+    assert(stateFromHistory.get.selection.isEmpty)
+  }
+
+  test("Navigation.Selection.toString") {
+    assert(Navigation.Selection(11, 1, 12, 1).toString == "L11")
+    assert(Navigation.Selection(11, 1, 12, 4).toString == "L11-L12C4")
+    assert(Navigation.Selection(11, 1, 12, 4).toString == "L11-L12C4")
+    assert(Navigation.Selection(11, 2, 12, 4).toString == "L11C2-L12C4")
+    assert(Navigation.Selection(11, 2, 12, 1).toString == "L11C2-L12")
+  }
+
+  test("Navigation.parseSelection") {
+    val str = "L10C4-L14C20"
+    val Some(parsed) = Navigation.parseSelection(str)
+
+    assert(parsed == Navigation.Selection(10, 4, 14, 20))
+    assert(parsed.toString == str)
+
+    assert(Navigation.parseSelection("L10-C1") == None)
+  }
+
+  test("Navigation.parseSelection normalization") {
+    val selection = Navigation.Selection(1, 1, 2, 1)
+    assert(Navigation.parseSelection("L1") == Some(selection))
+    assert(Navigation.parseSelection("L1-L2") == Some(selection))
+    assert(Navigation.parseSelection("L1C1-L2") == Some(selection))
+    assert(Navigation.parseSelection("L1-L2C1") == Some(selection))
+    assert(Navigation.parseSelection("L1C1-L2C1") == Some(selection))
+  }
+
+  test("Navigation.parseSelection roundtrip") {
+    val samples =
+      """L1
+        |L1-L3
+        |L1C2-L2
+        |L1-L1C2
+        |L110-L112C25
+        |
+        |L10-L2
+        |"""
+
+    samples.stripMargin.split('\n').filter(_.nonEmpty).foreach { selection =>
+      assert(
+        Navigation.parseSelection(selection).map(_.toString) == Some(selection)
+      )
+    }
+  }
+}

--- a/metadoc-js/src/test/scala/metadoc/NavigationTest.scala
+++ b/metadoc-js/src/test/scala/metadoc/NavigationTest.scala
@@ -13,7 +13,11 @@ class NavigationTest extends FunSuite {
     val stateWithSelection = Navigation.parseState("/path2#L11")
     assert(stateWithSelection.isDefined)
     assert(stateWithSelection.get.path == "/path2")
-    assert(stateWithSelection.get.selection == Some(Navigation.Selection(11, 1, 12, 1)))
+    assert(
+      stateWithSelection.get.selection == Some(
+        Navigation.Selection(11, 1, 12, 1)
+      )
+    )
 
     assert(Navigation.parseState("").isEmpty)
     assert(Navigation.parseState("#/path2#L11").isEmpty)
@@ -25,12 +29,18 @@ class NavigationTest extends FunSuite {
     assert(stateFromHash.get.path == "/path")
     assert(stateFromHash.get.selection.isEmpty)
 
-    val stateFromHashWithSelection = Navigation.currentState(None, "/path2#L11")
+    val stateFromHashWithSelection =
+      Navigation.currentState(None, "/path2#L11")
     assert(stateFromHashWithSelection.isDefined)
     assert(stateFromHashWithSelection.get.path == "/path2")
-    assert(stateFromHashWithSelection.get.selection == Some(Navigation.Selection(11, 1, 12, 1)))
+    assert(
+      stateFromHashWithSelection.get.selection == Some(
+        Navigation.Selection(11, 1, 12, 1)
+      )
+    )
 
-    val stateFromHistory = Navigation.currentState(stateFromHash, "/other-path")
+    val stateFromHistory =
+      Navigation.currentState(stateFromHash, "/other-path")
     assert(stateFromHistory.isDefined)
     assert(stateFromHistory.get.path == "/path")
     assert(stateFromHistory.get.selection.isEmpty)

--- a/metadoc-js/src/test/scala/metadoc/NavigationTest.scala
+++ b/metadoc-js/src/test/scala/metadoc/NavigationTest.scala
@@ -5,7 +5,7 @@ import monaco.Range
 
 class NavigationTest extends FunSuite {
   test("Navigation.parseState") {
-    val state = Navigation.currentState(None, "/path")
+    val state = Navigation.parseState("/path")
     assert(state.isDefined)
     assert(state.get.path == "/path")
     assert(state.get.selection.isEmpty)
@@ -23,7 +23,7 @@ class NavigationTest extends FunSuite {
     assert(Navigation.parseState("#/path2#L11").isEmpty)
   }
 
-  test("Navigation.curentState") {
+  test("Navigation.currentState") {
     val stateFromHash = Navigation.currentState(None, "/path")
     assert(stateFromHash.isDefined)
     assert(stateFromHash.get.path == "/path")
@@ -48,7 +48,6 @@ class NavigationTest extends FunSuite {
 
   test("Navigation.Selection.toString") {
     assert(Navigation.Selection(11, 1, 12, 1).toString == "L11")
-    assert(Navigation.Selection(11, 1, 12, 4).toString == "L11-L12C4")
     assert(Navigation.Selection(11, 1, 12, 4).toString == "L11-L12C4")
     assert(Navigation.Selection(11, 2, 12, 4).toString == "L11C2-L12C4")
     assert(Navigation.Selection(11, 2, 12, 1).toString == "L11C2-L12")

--- a/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
@@ -257,7 +257,6 @@ class MetadocCliTest
           .readAllBytes
       )
       val obtained = index.toString
-      println(obtained)
       assertNoDiff(obtained, expected)
     }
   }


### PR DESCRIPTION
I've been fiddling with this for quite a while so: **over-engineering alert!!**

Currently, the JS tests do not load Monaco which means no types inside the `monaco` package can be used, thus the navigation management is implemented using `java.net.URI` and custom types to track the navigation state.