### PR TITLE
Add support to generate metadoc from json files.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,9 +34,9 @@ inThisBuild(
 )
 
 lazy val Version = new {
-  def scala = "2.12.3"
+  def scala = "2.12.4"
   def scala210 = "2.10.6"
-  def scalameta = "2.0.0"
+  def scalameta = "2.1.5"
 }
 
 lazy val allSettings = Seq(
@@ -77,6 +77,7 @@ lazy val cli = project
     mainClass.in(assembly) := Some("metadoc.cli.MetadocCli"),
     assemblyJarName.in(assembly) := "metadoc.jar",
     libraryDependencies ++= List(
+      "com.trueaccord.scalapb" %% "scalapb-json4s" % "0.3.2",
       "com.github.alexarchambault" %% "case-app" % "1.2.0-M3",
       "com.github.pathikrit" %% "better-files" % "3.0.0"
     ),
@@ -211,7 +212,10 @@ lazy val tests = project
           compile.in(example, Test)
         )
         .value,
-    libraryDependencies += "org.scalameta" %% "testkit" % Version.scalameta % Test,
+    libraryDependencies ++= List(
+      "org.scalameta" %% "testkit" % Version.scalameta % Test,
+      "org.scalameta" % "semanticdb-scalac-core" % Version.scalameta % Test cross CrossVersion.full
+    ),
     buildInfoKeys := Seq[BuildInfoKey](
       "exampleClassDirectory" -> List(
         classDirectory.in(example, Compile).value,

--- a/metadoc-tests/src/test/scala/metadoc/tests/JsonSuite.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/JsonSuite.scala
@@ -1,0 +1,91 @@
+package metadoc.tests
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import scala.meta.Database
+import scala.meta.internal.semanticdb._
+import scala.meta.interactive._
+import scala.meta.testkit.DiffAssertions
+import scala.tools.nsc.interactive.Global
+import caseapp.RemainingArgs
+import com.trueaccord.scalapb.json.JsonFormat
+import metadoc.cli.MetadocCli
+import metadoc.cli.MetadocOptions
+import metadoc.schema.SymbolIndex
+import org.langmeta.internal.io.FileIO
+import org.langmeta.internal.io.PathIO
+import org.langmeta.io.AbsolutePath
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FunSuite
+
+class JsonSuite extends FunSuite with DiffAssertions with BeforeAndAfterAll {
+  val compiler: Global = InteractiveSemanticdb.newCompiler()
+  override def afterAll(): Unit = compiler.askShutdown()
+  test(".semanticdb.json") {
+    val doc = InteractiveSemanticdb.toDocument(
+      compiler,
+      """package com.bar
+        |import scala.concurrent.Future
+        |object Main {
+        |  val future = Future.successful(1)
+        |  Main.future.map(_ + 1)
+        |}
+      """.stripMargin
+    )
+    val db = Database(doc :: Nil).toSchema(PathIO.workingDirectory)
+    val dbJson = JsonFormat.toJsonString(db)
+    val jsonFile = Files.createTempFile("metadoc", ".semanticdb.json")
+    val out = Files.createTempDirectory("metadoc")
+    Files.write(jsonFile, dbJson.getBytes(StandardCharsets.UTF_8))
+    MetadocCli.run(
+      MetadocOptions(target = Some(out.toString)),
+      RemainingArgs(jsonFile.toString :: Nil, Nil)
+    )
+    val symbols = FileIO
+      .listAllFilesRecursively(AbsolutePath(out).resolve("symbol"))
+      .toList
+    assert(symbols.length == 2)
+    val index = symbols
+      .map(path => SymbolIndex.parseFrom(path.readAllBytes))
+      .sortBy(_.symbol)
+      .mkString("\n\n")
+    assertNoDiff(
+      index,
+      """
+        |symbol: "_root_.com.bar.Main."
+        |definition {
+        |  filename: "interactive.scala"
+        |  start: 54
+        |  end: 58
+        |}
+        |references {
+        |  key: "interactive.scala"
+        |  value {
+        |    ranges {
+        |      start: 99
+        |      end: 103
+        |    }
+        |  }
+        |}
+        |
+        |
+        |symbol: "_root_.com.bar.Main.future."
+        |definition {
+        |  filename: "interactive.scala"
+        |  start: 67
+        |  end: 73
+        |}
+        |references {
+        |  key: "interactive.scala"
+        |  value {
+        |    ranges {
+        |      start: 104
+        |      end: 110
+        |    }
+        |  }
+        |}
+        |
+      """.stripMargin
+    )
+  }
+}


### PR DESCRIPTION
In other languages than Scala, JSON might be more accessible output
format compared to protobuf. With this commit, it's possible to
run the cli with

```
metadoc --target=out some-project.semanticdb.json
```
to generate a metadoc site from a json file instead of semanticdb proto
files. A single .semanticdb.json file can document many files
and looks like this
https://gist.github.com/ff8ab12f3faa549887a7dcdd0069ab3f

Note that the synthetics and symbols sections are not necessary for "Go to definition" or "Find references", only the names section is required. However, we may need the symbols section later down the road to show types on hover


Ping @arnarthor