### PR TITLE
Upgrade to Scalameta v3.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "paiges"]
 	path = paiges
+	branch = three-lines
 	url = https://github.com/olafurpg/paiges.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "paiges"]
+	path = paiges
+	branch = b39af293549f806dc7ab0d6c172b41373e5068d5
+	url = https://github.com/typelevel/paiges.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "paiges"]
 	path = paiges
+	branch = v0.2.1
 	url = https://github.com/typelevel/paiges.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "paiges"]
 	path = paiges
-	branch = v0.2.1
-	url = https://github.com/typelevel/paiges.git
+	url = https://github.com/olafurpg/paiges.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "paiges"]
-	path = paiges
-	branch = three-lines
-	url = https://github.com/olafurpg/paiges.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ env:
     - TRAVIS_NODE_VERSION="8"
     - TRAVIS_YARN_VERSION="1.3.2"
 
-before_script:
-  git clone https://github.com/typelevel/paiges.git
-
 matrix:
   include:
     - script: sbt ci-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
     - TRAVIS_NODE_VERSION="8"
     - TRAVIS_YARN_VERSION="1.3.2"
 
+before_script:
+  git clone https://github.com/typelevel/paiges.git
+
 matrix:
   include:
     - script: sbt ci-test

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import com.trueaccord.scalapb.compiler.Version.scalapbVersion
+import scalapb.compiler.Version.scalapbVersion
 import scalajsbundler.util.JSON._
 
 inThisBuild(
@@ -47,8 +47,8 @@ inThisBuild(
 lazy val Version = new {
   def scala = "2.12.4"
   def scala210 = "2.10.6"
-  def scalameta = "2.1.5"
-  def sbt = "1.0.4"
+  def scalameta = "3.7.0"
+  def sbt = "1.1.1"
   def sbt013 = "0.13.17"
 }
 
@@ -93,7 +93,7 @@ lazy val cli = project
     mainClass.in(assembly) := Some("metadoc.cli.MetadocCli"),
     assemblyJarName.in(assembly) := "metadoc.jar",
     libraryDependencies ++= List(
-      "com.trueaccord.scalapb" %% "scalapb-json4s" % "0.3.2",
+      "com.thesamet.scalapb" %% "scalapb-json4s" % "0.7.0",
       "com.github.alexarchambault" %% "case-app" % "1.2.0-M3",
       "com.github.pathikrit" %% "better-files" % "3.0.0"
     ),
@@ -179,7 +179,7 @@ lazy val core = crossProject
     ),
     libraryDependencies ++= List(
       "org.scalameta" %%% "langmeta" % Version.scalameta,
-      "com.trueaccord.scalapb" %%% "scalapb-runtime" % scalapbVersion
+      "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapbVersion
     )
   )
 lazy val coreJVM = core.jvm

--- a/build.sbt
+++ b/build.sbt
@@ -246,7 +246,7 @@ lazy val tests = project
         .value,
     libraryDependencies ++= List(
       "org.scalameta" %% "testkit" % Version.scalameta % Test,
-      "org.scalameta" % "semanticdb-scalac-core" % Version.scalameta % Test cross CrossVersion.full
+      "org.scalameta" % "interactive" % Version.scalameta % Test cross CrossVersion.full
     ),
     buildInfoKeys := Seq[BuildInfoKey](
       "exampleClassDirectory" -> List(

--- a/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
+++ b/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
@@ -255,7 +255,8 @@ class CliRunner(classpath: Seq[AbsolutePath], options: MetadocOptions) {
             Symbol.Global(owner, Signature.Term(name)).syntax
           )
           if syntheticObjRef.get().definition.isEmpty
-        } yield symbolIndex.copy(references = syntheticObjRef.get().references))
+        } yield
+          symbolIndex.copy(references = syntheticObjRef.get().references))
           .getOrElse(symbolIndex)
       case _ => symbolIndex
     }

--- a/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
+++ b/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
@@ -25,7 +25,7 @@ import scala.collection.parallel.mutable.ParArray
 import scala.util.control.NonFatal
 import caseapp._
 import caseapp.core.Messages
-import com.trueaccord.scalapb.json.JsonFormat
+import scalapb.json4s.JsonFormat
 import metadoc.schema
 import metadoc.schema.SymbolIndex
 import metadoc.{schema => d}

--- a/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
+++ b/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
@@ -30,7 +30,8 @@ import metadoc.schema
 import metadoc.schema.SymbolIndex
 import metadoc.{schema => d}
 import org.langmeta._
-import org.langmeta.internal.semanticdb.{schema => s}
+import scala.meta.internal.{semanticdb3 => s}
+import metadoc.MetadocEnrichments._
 
 @AppName("metadoc")
 @AppVersion("0.1.0-SNAPSHOT")
@@ -162,14 +163,14 @@ class CliRunner(classpath: Seq[AbsolutePath], options: MetadocOptions) {
       files.result()
     }
 
-  private def parseDatabase(path: AbsolutePath): s.Database = {
+  private def parseDatabase(path: AbsolutePath): s.TextDocuments = {
     val filename = path.toNIO.getFileName.toString
     val bytes = path.readAllBytes
     if (filename.endsWith(".semanticdb")) {
-      s.Database.parseFrom(bytes)
+      s.TextDocuments.parseFrom(bytes)
     } else if (filename.endsWith(".semanticdb.json")) {
       val string = new String(bytes, StandardCharsets.UTF_8)
-      JsonFormat.fromJsonString[s.Database](string)
+      JsonFormat.fromJsonString[s.TextDocuments](string)
     } else {
       throw new IllegalArgumentException(s"Unexpected filename $filename")
     }
@@ -182,26 +183,34 @@ class CliRunner(classpath: Seq[AbsolutePath], options: MetadocOptions) {
           tick()
           val db = parseDatabase(path)
           db.documents.foreach { document =>
-            document.names.foreach {
-              case s.ResolvedName(_, sym, _)
+            document.occurrences.foreach {
+              case s.SymbolOccurrence(_, sym, _)
                   if !sym.endsWith(".") && !sym.endsWith("#") =>
               // Do nothing, local symbol.
-              case s.ResolvedName(Some(s.Position(start, end)), sym, true) =>
-                addDefinition(sym, d.Position(document.filename, start, end))
-              case s.ResolvedName(Some(s.Position(start, end)), sym, false) =>
-                addReference(document.filename, d.Range(start, end), sym)
+              case s.SymbolOccurrence(
+                  Some(r),
+                  sym,
+                  s.SymbolOccurrence.Role.DEFINITION
+                  ) =>
+                addDefinition(sym, r.toPosition(document.uri))
+              case s.SymbolOccurrence(
+                  Some(r),
+                  sym,
+                  s.SymbolOccurrence.Role.REFERENCE
+                  ) =>
+                addReference(document.uri, r.toDocRange, sym)
               case _ =>
             }
-            val out = semanticdb.resolve(document.filename)
+            val out = semanticdb.resolve(document.uri)
             Files.createDirectories(out.toNIO.getParent)
             overwrite(
               out.toNIO
                 .resolveSibling(
                   out.toNIO.getFileName.toString + ".semanticdb"
                 ),
-              s.Database(document :: Nil).toByteArray
+              s.TextDocuments(document :: Nil).toByteArray
             )
-            filenames.add(document.filename)
+            filenames.add(document.uri)
           }
         } catch {
           case NonFatal(e) =>
@@ -246,8 +255,7 @@ class CliRunner(classpath: Seq[AbsolutePath], options: MetadocOptions) {
             Symbol.Global(owner, Signature.Term(name)).syntax
           )
           if syntheticObjRef.get().definition.isEmpty
-        } yield
-          symbolIndex.copy(references = syntheticObjRef.get().references))
+        } yield symbolIndex.copy(references = syntheticObjRef.get().references))
           .getOrElse(symbolIndex)
       case _ => symbolIndex
     }

--- a/metadoc-core/src/main/protobuf/metadoc.proto
+++ b/metadoc-core/src/main/protobuf/metadoc.proto
@@ -4,8 +4,10 @@ package metadoc.schema;
 
 message Position {
     string filename = 1;
-    int32 start = 2;
-    int32 end = 3;
+    int32 startLine = 2;
+    int32 startCharacter = 3;
+    int32 endLine = 4;
+    int32 endCharacter = 5;
 }
 
 message SymbolIndex {
@@ -16,8 +18,10 @@ message SymbolIndex {
 }
 
 message Range {
-    int32 start = 2;
-    int32 end = 3;
+    int32 startLine = 1;
+    int32 startCharacter = 2;
+    int32 endLine = 3;
+    int32 endCharacter = 4;
 }
 
 message Ranges {

--- a/metadoc-core/src/main/scala/metadoc/MetadocEnrichments.scala
+++ b/metadoc-core/src/main/scala/metadoc/MetadocEnrichments.scala
@@ -1,0 +1,39 @@
+package metadoc
+
+import metadoc.{schema => d}
+import org.{langmeta => m}
+import scala.meta.internal.{semanticdb3 => s}
+
+object MetadocEnrichments {
+  implicit class XtensionMetadocRange(val r: d.Range) extends AnyVal {
+    def toPosition(uri: String): d.Position = {
+      d.Position(
+        uri,
+        r.startLine,
+        r.startCharacter,
+        r.endLine,
+        r.endCharacter
+      )
+    }
+  }
+  implicit class XtensionSemanticdbRange(val r: s.Range) extends AnyVal {
+    def toDocRange: d.Range = {
+      d.Range(
+        r.startLine,
+        r.startCharacter,
+        r.endLine,
+        r.endCharacter
+      )
+    }
+    def toPosition(uri: String): d.Position = {
+      d.Position(
+        uri,
+        r.startLine,
+        r.startCharacter,
+        r.endLine,
+        r.endCharacter
+      )
+    }
+  }
+
+}

--- a/metadoc-core/src/main/scala/metadoc/MetadocEvent.scala
+++ b/metadoc-core/src/main/scala/metadoc/MetadocEvent.scala
@@ -1,8 +1,8 @@
 package metadoc
 
-import org.langmeta.internal.semanticdb.{schema => s}
+import scala.meta.internal.{semanticdb3 => s}
 
 sealed abstract class MetadocEvent
 object MetadocEvent {
-  case class SetDocument(document: s.Document) extends MetadocEvent
+  case class SetDocument(document: s.TextDocument) extends MetadocEvent
 }

--- a/metadoc-core/src/main/scala/metadoc/MetadocSemanticdbIndex.scala
+++ b/metadoc-core/src/main/scala/metadoc/MetadocSemanticdbIndex.scala
@@ -3,52 +3,68 @@ package metadoc
 import scala.concurrent.Future
 import metadoc.{schema => d}
 import org.{langmeta => m}
-import org.langmeta.internal.semanticdb.{schema => s}
+import scala.meta.internal.{semanticdb3 => s}
+import MetadocEnrichments._
 
 /** Index to lookup symbol definitions and references. */
 trait MetadocSemanticdbIndex {
-  def document: s.Document
+  def document: s.TextDocument
   def symbol(sym: String): Future[Option[d.SymbolIndex]]
-  def semanticdb(sym: String): Future[Option[s.Document]]
+  def semanticdb(sym: String): Future[Option[s.TextDocument]]
   def dispatch(event: MetadocEvent): Unit
 
   def definition(symbol: String): Option[d.Position] =
-    document.names.collectFirst {
-      case s.ResolvedName(Some(s.Position(start, end)), `symbol`, true) =>
-        d.Position(document.filename, start, end)
+    document.occurrences.collectFirst {
+      case s.SymbolOccurrence(
+          Some(r),
+          `symbol`,
+          s.SymbolOccurrence.Role.DEFINITION
+          ) =>
+        r.toPosition(document.uri)
     }
 
-  def resolve(offset: Int): Option[s.ResolvedName] = {
+  def resolve(offset: Int): Option[s.SymbolOccurrence] = {
+    val input = m.Input.VirtualFile(document.uri, document.text)
+    val mpos = m.Position.Range(input, offset, offset)
+    val line = mpos.startLine
+    val character = mpos.startColumn
     // TODO(olafur) binary search.
-    document.names.collectFirst {
-      case name @ s.ResolvedName(Some(pos), _, _)
-          if pos.start <= offset && offset <= pos.end =>
+    document.occurrences.collectFirst {
+      case name @ s.SymbolOccurrence(Some(pos), _, _)
+          if pos.startLine <= line &&
+            pos.startCharacter <= character &&
+            line <= pos.endLine &&
+            character <= pos.endCharacter =>
         name
     }
   }
 
   def fetchSymbol(offset: Int): Future[Option[d.SymbolIndex]] =
     resolve(offset).fold(Future.successful(Option.empty[d.SymbolIndex])) {
-      case s.ResolvedName(_, sym, _) =>
+      case s.SymbolOccurrence(_, sym, _) =>
         m.Symbol(sym) match {
           case m.Symbol.Global(_, _) =>
             symbol(sym)
           case _ =>
             // Resolve from local open document.
-            val names = document.names.filter(_.symbol == sym)
+            val names = document.occurrences.filter(_.symbol == sym)
             val definition = names.collectFirst {
-              case s.ResolvedName(Some(s.Position(start, end)), _, true) =>
-                d.Position(document.filename, start, end)
+              case s.SymbolOccurrence(
+                  Some(r),
+                  _,
+                  s.SymbolOccurrence.Role.DEFINITION
+                  ) =>
+                r.toPosition(document.uri)
             }
             val references = Map(
-              document.filename -> d.Ranges(
+              document.uri -> d.Ranges(
                 names.collect {
-                  case s.ResolvedName(
-                      Some(s.Position(start, end)),
+                  case s.SymbolOccurrence(
+                      Some(r),
                       _,
-                      false
+                      s.SymbolOccurrence.Role.REFERENCE
                       ) =>
-                    d.Range(start, end)
+                    r.toDocRange
                 }
               )
             )

--- a/metadoc-js/src/main/scala/metadoc/DocumentSymbol.scala
+++ b/metadoc-js/src/main/scala/metadoc/DocumentSymbol.scala
@@ -3,10 +3,11 @@ package metadoc
 import monaco.languages.SymbolKind
 import org.{langmeta => m}
 import metadoc.{schema => d}
+import scala.meta.internal.semanticdb3.SymbolInformation
 
 /** "Go to symbol" eligible definition */
 case class DocumentSymbol(
-    denotation: m.Denotation,
+    info: SymbolInformation,
     kind: SymbolKind,
     definition: d.Position
 )

--- a/metadoc-js/src/main/scala/metadoc/MetadocApp.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocApp.scala
@@ -17,7 +17,7 @@ import monaco.editor.IModelChangedEvent
 import monaco.languages.ILanguageExtensionPoint
 import monaco.services.{IResourceInput, ITextEditorOptions}
 import org.scalajs.dom
-import org.langmeta.internal.semanticdb.{schema => s}
+import scala.meta.internal.{ semanticdb3 => s}
 
 object MetadocApp {
   def main(args: Array[String]): Unit = {
@@ -45,7 +45,7 @@ object MetadocApp {
       _ <- loadMonaco()
       workspace <- MetadocFetch.workspace()
     } {
-      val index = new MutableBrowserIndex(MetadocState(s.Document()))
+      val index = new MutableBrowserIndex(MetadocState(s.TextDocument()))
       registerLanguageExtensions(index)
       val editorService = new MetadocEditorService(index)
 

--- a/metadoc-js/src/main/scala/metadoc/MetadocApp.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocApp.scala
@@ -17,7 +17,7 @@ import monaco.editor.IModelChangedEvent
 import monaco.languages.ILanguageExtensionPoint
 import monaco.services.{IResourceInput, ITextEditorOptions}
 import org.scalajs.dom
-import scala.meta.internal.{ semanticdb3 => s}
+import scala.meta.internal.{semanticdb3 => s}
 
 object MetadocApp {
   def main(args: Array[String]): Unit = {

--- a/metadoc-js/src/main/scala/metadoc/MetadocFetch.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocFetch.scala
@@ -2,7 +2,7 @@ package metadoc
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import org.langmeta.internal.semanticdb.{schema => s}
+import scala.meta.internal.{ semanticdb3 => s}
 import metadoc.MetadocApp._
 import metadoc.{schema => d}
 
@@ -17,12 +17,12 @@ object MetadocFetch {
     }
   }.recover(or404)
 
-  def document(filename: String): Future[Option[s.Document]] = {
+  def document(filename: String): Future[Option[s.TextDocument]] = {
     val url = "semanticdb/" + filename + ".semanticdb"
     for {
       bytes <- fetchBytes(url)
     } yield {
-      Some(s.Database.parseFrom(bytes).documents.head)
+      Some(s.TextDocuments.parseFrom(bytes).documents.head)
     }
   }.recover(or404)
 

--- a/metadoc-js/src/main/scala/metadoc/MetadocFetch.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocFetch.scala
@@ -2,7 +2,7 @@ package metadoc
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.meta.internal.{ semanticdb3 => s}
+import scala.meta.internal.{semanticdb3 => s}
 import metadoc.MetadocApp._
 import metadoc.{schema => d}
 

--- a/metadoc-js/src/main/scala/metadoc/MetadocMonacoDocument.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocMonacoDocument.scala
@@ -2,7 +2,7 @@ package metadoc
 
 import monaco.services.IReference
 import monaco.services.ITextEditorModel
-import org.langmeta.internal.semanticdb.{schema => s}
+import scala.meta.internal.{ semanticdb3 => s}
 
 /** Logicless wrapper around a metadoc+monaco document/model.
   *
@@ -10,6 +10,6 @@ import org.langmeta.internal.semanticdb.{schema => s}
   * @param model Monaco model for a document.
   */
 case class MetadocMonacoDocument(
-    document: s.Document,
+    document: s.TextDocument,
     model: IReference[ITextEditorModel]
 )

--- a/metadoc-js/src/main/scala/metadoc/MetadocMonacoDocument.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocMonacoDocument.scala
@@ -2,7 +2,7 @@ package metadoc
 
 import monaco.services.IReference
 import monaco.services.ITextEditorModel
-import scala.meta.internal.{ semanticdb3 => s}
+import scala.meta.internal.{semanticdb3 => s}
 
 /** Logicless wrapper around a metadoc+monaco document/model.
   *

--- a/metadoc-js/src/main/scala/metadoc/MetadocTextModelService.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocTextModelService.scala
@@ -11,7 +11,7 @@ import monaco.services.IReference
 import monaco.services.ITextEditorModel
 import monaco.services.ITextModelService
 import monaco.services.ImmortalReference
-import org.langmeta.internal.semanticdb.{schema => s}
+import scala.meta.internal.{ semanticdb3 => s}
 
 object MetadocTextModelService extends ITextModelService {
   def modelReference(
@@ -20,7 +20,7 @@ object MetadocTextModelService extends ITextModelService {
     modelDocument(createUri(filename)).map(_.model)
 
   // TODO(olafur): Move this state out for easier testing.
-  private val modelDocumentCache = mutable.Map.empty[IModel, s.Document]
+  private val modelDocumentCache = mutable.Map.empty[IModel, s.TextDocument]
 
   private def document(model: IModel) =
     MetadocMonacoDocument(
@@ -38,7 +38,7 @@ object MetadocTextModelService extends ITextModelService {
       for {
         Some(doc) <- MetadocFetch.document(resource.path)
       } yield {
-        val model = Editor.createModel(doc.contents, "scala", resource)
+        val model = Editor.createModel(doc.text, "scala", resource)
         modelDocumentCache(model) = doc
         document(model)
       }

--- a/metadoc-js/src/main/scala/metadoc/MetadocTextModelService.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocTextModelService.scala
@@ -11,7 +11,7 @@ import monaco.services.IReference
 import monaco.services.ITextEditorModel
 import monaco.services.ITextModelService
 import monaco.services.ImmortalReference
-import scala.meta.internal.{ semanticdb3 => s}
+import scala.meta.internal.{semanticdb3 => s}
 
 object MetadocTextModelService extends ITextModelService {
   def modelReference(

--- a/metadoc-js/src/main/scala/metadoc/MutableBrowserIndex.scala
+++ b/metadoc-js/src/main/scala/metadoc/MutableBrowserIndex.scala
@@ -1,8 +1,8 @@
 package metadoc
 
 import scala.concurrent.Future
-import org.langmeta.internal.semanticdb.schema.Document
-import org.langmeta.internal.semanticdb.{schema => s}
+import scala.meta.internal.semanticdb3.TextDocument
+import scala.meta.internal.{ semanticdb3 => s}
 
 class MutableBrowserIndex(init: MetadocState) extends MetadocSemanticdbIndex {
   private var state: MetadocState = init
@@ -11,11 +11,11 @@ class MutableBrowserIndex(init: MetadocState) extends MetadocSemanticdbIndex {
     case MetadocEvent.SetDocument(document) =>
       state = state.copy(document = document)
   }
-  override def document: Document = state.document
+  override def document: TextDocument = state.document
   override def symbol(sym: String): Future[Option[schema.SymbolIndex]] =
     MetadocFetch.symbol(sym)
-  override def semanticdb(sym: String): Future[Option[s.Document]] =
+  override def semanticdb(sym: String): Future[Option[s.TextDocument]] =
     MetadocFetch.document(sym)
 }
 
-case class MetadocState(document: s.Document)
+case class MetadocState(document: s.TextDocument)

--- a/metadoc-js/src/main/scala/metadoc/MutableBrowserIndex.scala
+++ b/metadoc-js/src/main/scala/metadoc/MutableBrowserIndex.scala
@@ -2,7 +2,7 @@ package metadoc
 
 import scala.concurrent.Future
 import scala.meta.internal.semanticdb3.TextDocument
-import scala.meta.internal.{ semanticdb3 => s}
+import scala.meta.internal.{semanticdb3 => s}
 
 class MutableBrowserIndex(init: MetadocState) extends MetadocSemanticdbIndex {
   private var state: MetadocState = init

--- a/metadoc-js/src/main/scala/metadoc/ScalaDocumentSymbolProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaDocumentSymbolProvider.scala
@@ -40,7 +40,7 @@ class ScalaDocumentSymbolProvider(index: MetadocSemanticdbIndex)
         case DocumentSymbol(denotation, kind, definition) =>
           new SymbolInformation(
             name = denotation.name,
-            // TODO: pretty print `.tpe`
+            // TODO: pretty print `.tpe`: https://github.com/scalameta/scalameta/issues/1479
             containerName = denotation.symbol,
             kind = kind,
             location = model.resolveLocation(definition)

--- a/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaReferenceProvider.scala
@@ -9,6 +9,7 @@ import monaco.languages.ReferenceContext
 import monaco.languages.ReferenceProvider
 import monaco.CancellationToken
 import monaco.Position
+import MetadocEnrichments._
 
 class ScalaReferenceProvider(index: MetadocSemanticdbIndex)
     extends ReferenceProvider {
@@ -32,9 +33,9 @@ class ScalaReferenceProvider(index: MetadocSemanticdbIndex)
               .modelDocument(createUri(filename))
               .map {
                 case MetadocMonacoDocument(_, model) =>
-                  ranges.ranges.map { range =>
+                  ranges.ranges.map { r =>
                     model.`object`.textEditorModel.resolveLocation(
-                      schema.Position(filename, range.start, range.end)
+                      r.toPosition(filename)
                     )
                   }
               }

--- a/metadoc-js/src/main/scala/metadoc/package.scala
+++ b/metadoc-js/src/main/scala/metadoc/package.scala
@@ -51,13 +51,11 @@ package object metadoc {
   implicit class XtensionIReadOnlyModel(val self: IReadOnlyModel)
       extends AnyVal {
     def resolveLocation(pos: d.Position): Location = {
-      val startPos = self.getPositionAt(pos.start)
-      val endPos = self.getPositionAt(pos.end)
       val range = new Range(
-        startPos.lineNumber,
-        startPos.column,
-        endPos.lineNumber,
-        endPos.column
+        pos.startLine,
+        pos.startCharacter,
+        pos.endLine,
+        pos.endCharacter
       )
       val uri = createUri(pos.filename)
       val location = new Location(uri, range)

--- a/metadoc-js/src/main/scala/metadoc/package.scala
+++ b/metadoc-js/src/main/scala/metadoc/package.scala
@@ -52,10 +52,10 @@ package object metadoc {
       extends AnyVal {
     def resolveLocation(pos: d.Position): Location = {
       val range = new Range(
-        pos.startLine,
-        pos.startCharacter,
-        pos.endLine,
-        pos.endCharacter
+        pos.startLine + 1,
+        pos.startCharacter + 1,
+        pos.endLine + 1,
+        pos.endCharacter + 1
       )
       val uri = createUri(pos.filename)
       val location = new Location(uri, range)

--- a/metadoc-js/src/main/scala/monaco/Monaco.scala
+++ b/metadoc-js/src/main/scala/monaco/Monaco.scala
@@ -2253,7 +2253,7 @@ package languages {
   sealed trait DocumentHighlightKind extends js.Object {}
 
   @js.native
-  @JSGlobal("monaco.languages.DocumentHighlightKind")
+  @JSGlobal("monaco.languages.TextDocumentHighlightKind")
   object DocumentHighlightKind extends js.Object {
     var Text: DocumentHighlightKind = js.native
     var Read: DocumentHighlightKind = js.native

--- a/metadoc-js/src/main/scala/monaco/Monaco.scala
+++ b/metadoc-js/src/main/scala/monaco/Monaco.scala
@@ -2253,7 +2253,7 @@ package languages {
   sealed trait DocumentHighlightKind extends js.Object {}
 
   @js.native
-  @JSGlobal("monaco.languages.TextDocumentHighlightKind")
+  @JSGlobal("monaco.languages.DocumentHighlightKind")
   object DocumentHighlightKind extends js.Object {
     var Text: DocumentHighlightKind = js.native
     var Read: DocumentHighlightKind = js.native

--- a/metadoc-tests/src/test/scala/metadoc/tests/JsonSuite.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/JsonSuite.scala
@@ -48,43 +48,51 @@ class JsonSuite extends FunSuite with DiffAssertions with BeforeAndAfterAll {
     val index = symbols
       .map(path => SymbolIndex.parseFrom(path.readAllBytes))
       .sortBy(_.symbol)
+      .map(_.toProtoString)
       .mkString("\n\n")
     assertNoDiff(
       index,
       """
-        |symbol: "_root_.com.bar.Main."
+        |symbol: "com.bar.Main."
         |definition {
         |  filename: "interactive.scala"
-        |  start: 54
-        |  end: 58
+        |  startLine: 2
+        |  startCharacter: 7
+        |  endLine: 2
+        |  endCharacter: 11
         |}
         |references {
         |  key: "interactive.scala"
         |  value {
         |    ranges {
-        |      start: 99
-        |      end: 103
+        |      startLine: 4
+        |      startCharacter: 2
+        |      endLine: 4
+        |      endCharacter: 6
         |    }
         |  }
         |}
         |
         |
-        |symbol: "_root_.com.bar.Main.future."
+        |symbol: "com.bar.Main.future()."
         |definition {
         |  filename: "interactive.scala"
-        |  start: 67
-        |  end: 73
+        |  startLine: 3
+        |  startCharacter: 6
+        |  endLine: 3
+        |  endCharacter: 12
         |}
         |references {
         |  key: "interactive.scala"
         |  value {
         |    ranges {
-        |      start: 104
-        |      end: 110
+        |      startLine: 4
+        |      startCharacter: 7
+        |      endLine: 4
+        |      endCharacter: 13
         |    }
         |  }
         |}
-        |
       """.stripMargin
     )
   }

--- a/metadoc-tests/src/test/scala/metadoc/tests/JsonSuite.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/JsonSuite.scala
@@ -8,7 +8,7 @@ import scala.meta.interactive._
 import scala.meta.testkit.DiffAssertions
 import scala.tools.nsc.interactive.Global
 import caseapp.RemainingArgs
-import com.trueaccord.scalapb.json.JsonFormat
+import scalapb.json4s.JsonFormat
 import metadoc.cli.MetadocCli
 import metadoc.cli.MetadocOptions
 import metadoc.schema.SymbolIndex

--- a/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliSuite.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliSuite.scala
@@ -11,7 +11,7 @@ import org.langmeta.io.AbsolutePath
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FunSuite
 
-class MetadocCliTest
+class MetadocCliSuite
     extends FunSuite
     with BeforeAndAfterAll
     with DiffAssertions {
@@ -62,7 +62,7 @@ class MetadocCliTest
     val expected =
       """|
          |org.typelevel.paiges.Chunk.
-         |org.typelevel.paiges.Chunk.best(Int,Doc).
+         |org.typelevel.paiges.Chunk.best(Int,Doc,Boolean).
          |org.typelevel.paiges.Chunk.indentMax.
          |org.typelevel.paiges.Chunk.indentTable.
          |org.typelevel.paiges.Chunk.lineToStr(Int).
@@ -95,7 +95,10 @@ class MetadocCliTest
          |org.typelevel.paiges.Doc#nested(Int).
          |org.typelevel.paiges.Doc#nonEmpty().
          |org.typelevel.paiges.Doc#render(Int).
+         |org.typelevel.paiges.Doc#renderGen(Int,Boolean).
          |org.typelevel.paiges.Doc#renderStream(Int).
+         |org.typelevel.paiges.Doc#renderStreamTrim(Int).
+         |org.typelevel.paiges.Doc#renderTrim(Int).
          |org.typelevel.paiges.Doc#renderWideStream().
          |org.typelevel.paiges.Doc#repeat(Int).
          |org.typelevel.paiges.Doc#representation(Boolean).
@@ -104,6 +107,8 @@ class MetadocCliTest
          |org.typelevel.paiges.Doc#tightBracketBy(Doc,Doc,Int).
          |org.typelevel.paiges.Doc#toString().
          |org.typelevel.paiges.Doc#writeTo(Int,PrintWriter).
+         |org.typelevel.paiges.Doc#writeToGen(Int,PrintWriter,Boolean).
+         |org.typelevel.paiges.Doc#writeToTrim(Int,PrintWriter).
          |org.typelevel.paiges.Doc.
          |org.typelevel.paiges.Doc.Align#
          |org.typelevel.paiges.Doc.Align#`<init>`(Doc).
@@ -169,6 +174,14 @@ class MetadocCliTest
          |org.typelevel.paiges.Document.
          |org.typelevel.paiges.Document.FromToString.
          |org.typelevel.paiges.Document.FromToString.document(Any).
+         |org.typelevel.paiges.Document.Ops#
+         |org.typelevel.paiges.Document.Ops#$init$().
+         |org.typelevel.paiges.Document.Ops#doc().
+         |org.typelevel.paiges.Document.Ops#instance().
+         |org.typelevel.paiges.Document.Ops#self().
+         |org.typelevel.paiges.Document.ToDocumentOps#
+         |org.typelevel.paiges.Document.ToDocumentOps#$init$().
+         |org.typelevel.paiges.Document.ToDocumentOps#toDocumentOps(A,Document).
          |org.typelevel.paiges.Document.apply(Document).
          |org.typelevel.paiges.Document.documentBoolean().
          |org.typelevel.paiges.Document.documentByte().
@@ -182,6 +195,7 @@ class MetadocCliTest
          |org.typelevel.paiges.Document.documentString().
          |org.typelevel.paiges.Document.documentUnit().
          |org.typelevel.paiges.Document.instance(Function1).
+         |org.typelevel.paiges.Document.ops.
          |org.typelevel.paiges.Document.useToString().
          |org.typelevel.paiges.DocumentTest#
          |org.typelevel.paiges.DocumentTest#`<init>`().
@@ -234,6 +248,7 @@ class MetadocCliTest
          |org.typelevel.paiges.PaigesTest#
          |org.typelevel.paiges.PaigesTest#`<init>`().
          |org.typelevel.paiges.PaigesTest#generatorDrivenConfig().
+         |org.typelevel.paiges.PaigesTest#slowRenderTrim(Doc,Int).
          |org.typelevel.paiges.PaigesTest.
          |org.typelevel.paiges.PaigesTest.EquivSyntax#
          |org.typelevel.paiges.PaigesTest.EquivSyntax#`<init>`(Doc).
@@ -267,8 +282,6 @@ class MetadocCliTest
           .readAllBytes
       )
       val obtained = index.toProtoString
-      println(obtained)
-      println()
       assertNoDiff(obtained, expected)
     }
   }

--- a/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
@@ -34,9 +34,9 @@ class MetadocCliTest
   val expectedFiles =
     """paiges/core/src/main/scala/org/typelevel/paiges/Chunk.scala.semanticdb
       |paiges/core/src/main/scala/org/typelevel/paiges/Doc.scala.semanticdb
-      |paiges/core/src/main/scala/org/typelevel/paiges.TextDocument.scala.semanticdb
+      |paiges/core/src/main/scala/org/typelevel/paiges/Document.scala.semanticdb
       |paiges/core/src/main/scala/org/typelevel/paiges/package.scala.semanticdb
-      |paiges/core/src/test/scala/org/typelevel/paiges.TextDocumentTests.scala.semanticdb
+      |paiges/core/src/test/scala/org/typelevel/paiges/DocumentTests.scala.semanticdb
       |paiges/core/src/test/scala/org/typelevel/paiges/Generators.scala.semanticdb
       |paiges/core/src/test/scala/org/typelevel/paiges/JsonTest.scala.semanticdb
       |paiges/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala.semanticdb
@@ -60,181 +60,189 @@ class MetadocCliTest
       .sorted
       .mkString("\n")
     val expected =
-      """|_root_.org.typelevel.paiges.Chunk.
-         |_root_.org.typelevel.paiges.Chunk.best(ILorg/typelevel/paiges/Doc;)Lscala/collection/Iterator;.
-         |_root_.org.typelevel.paiges.Chunk.indentMax.
-         |_root_.org.typelevel.paiges.Chunk.indentTable.
-         |_root_.org.typelevel.paiges.Chunk.lineToStr(I)Ljava/lang/String;.
-         |_root_.org.typelevel.paiges.Chunk.makeIndentStr(I)Ljava/lang/String;.
-         |_root_.org.typelevel.paiges.Doc#
-         |_root_.org.typelevel.paiges.Doc#`&:`(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#`&`(Lorg/typelevel/paiges/Doc;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#`*`(I)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#`+:`(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#`+`(Lorg/typelevel/paiges/Doc;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#`/:`(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#`/`(Lorg/typelevel/paiges/Doc;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#`:&`(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#`:+`(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#`:/`(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#`<init>`()V.
-         |_root_.org.typelevel.paiges.Doc#aligned()Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#bracketBy(Lorg/typelevel/paiges/Doc;Lorg/typelevel/paiges/Doc;I)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#flatten()Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#flattenBoolean()Lscala/Tuple2;.
-         |_root_.org.typelevel.paiges.Doc#flattenOption()Lscala/Option;.
-         |_root_.org.typelevel.paiges.Doc#grouped()Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#hashCode.
-         |_root_.org.typelevel.paiges.Doc#isEmpty()Z.
-         |_root_.org.typelevel.paiges.Doc#line(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#line(Lorg/typelevel/paiges/Doc;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#lineOrSpace(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#lineOrSpace(Lorg/typelevel/paiges/Doc;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#maxWidth()I.
-         |_root_.org.typelevel.paiges.Doc#nested(I)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#nonEmpty()Z.
-         |_root_.org.typelevel.paiges.Doc#render(I)Ljava/lang/String;.
-         |_root_.org.typelevel.paiges.Doc#renderStream(I)Lscala/collection/immutable/Stream;.
-         |_root_.org.typelevel.paiges.Doc#renderWideStream()Lscala/collection/immutable/Stream;.
-         |_root_.org.typelevel.paiges.Doc#repeat(I)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#representation(Z)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#space(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#space(Lorg/typelevel/paiges/Doc;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#tightBracketBy(Lorg/typelevel/paiges/Doc;Lorg/typelevel/paiges/Doc;I)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc#toString()Ljava/lang/String;.
-         |_root_.org.typelevel.paiges.Doc#writeTo(ILjava/io/PrintWriter;)V.
-         |_root_.org.typelevel.paiges.Doc.
-         |_root_.org.typelevel.paiges.Doc.Align#
-         |_root_.org.typelevel.paiges.Doc.Align#`<init>`(Lorg/typelevel/paiges/Doc;)V.
-         |_root_.org.typelevel.paiges.Doc.Align.
-         |_root_.org.typelevel.paiges.Doc.Concat#
-         |_root_.org.typelevel.paiges.Doc.Concat#`<init>`(Lorg/typelevel/paiges/Doc;Lorg/typelevel/paiges/Doc;)V.
-         |_root_.org.typelevel.paiges.Doc.Concat.
-         |_root_.org.typelevel.paiges.Doc.Empty.
-         |_root_.org.typelevel.paiges.Doc.Line#
-         |_root_.org.typelevel.paiges.Doc.Line#`<init>`(Z)V.
-         |_root_.org.typelevel.paiges.Doc.Line#asFlatDoc()Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.Line.
-         |_root_.org.typelevel.paiges.Doc.Nest#
-         |_root_.org.typelevel.paiges.Doc.Nest#`<init>`(ILorg/typelevel/paiges/Doc;)V.
-         |_root_.org.typelevel.paiges.Doc.Nest.
-         |_root_.org.typelevel.paiges.Doc.Text#
-         |_root_.org.typelevel.paiges.Doc.Text#`<init>`(Ljava/lang/String;)V.
-         |_root_.org.typelevel.paiges.Doc.Text.
-         |_root_.org.typelevel.paiges.Doc.Union#
-         |_root_.org.typelevel.paiges.Doc.Union#`<init>`(Lorg/typelevel/paiges/Doc;Lscala/Function0;)V.
-         |_root_.org.typelevel.paiges.Doc.Union#bDoc.
-         |_root_.org.typelevel.paiges.Doc.Union.
-         |_root_.org.typelevel.paiges.Doc.cat(Lscala/collection/Iterable;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.char(C)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.charTable.
-         |_root_.org.typelevel.paiges.Doc.comma.
-         |_root_.org.typelevel.paiges.Doc.empty.
-         |_root_.org.typelevel.paiges.Doc.equivAtWidths(Lscala/collection/immutable/List;)Lscala/math/Equiv;.
-         |_root_.org.typelevel.paiges.Doc.fill(Lorg/typelevel/paiges/Doc;Lscala/collection/Iterable;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.foldDocs(Lscala/collection/Iterable;Lscala/Function2;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.intercalate(Lorg/typelevel/paiges/Doc;Lscala/collection/Iterable;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.line.
-         |_root_.org.typelevel.paiges.Doc.lineBreak.
-         |_root_.org.typelevel.paiges.Doc.lineOrEmpty.
-         |_root_.org.typelevel.paiges.Doc.lineOrSpace.
-         |_root_.org.typelevel.paiges.Doc.maxSpaceTable.
-         |_root_.org.typelevel.paiges.Doc.orderingAtWidth(I)Lscala/math/Ordering;.
-         |_root_.org.typelevel.paiges.Doc.paragraph(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.space.
-         |_root_.org.typelevel.paiges.Doc.spaceArray.
-         |_root_.org.typelevel.paiges.Doc.spaces(I)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.split(Ljava/lang/String;Lscala/util/matching/Regex;Lorg/typelevel/paiges/Doc;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.splitWhitespace.
-         |_root_.org.typelevel.paiges.Doc.spread(Lscala/collection/Iterable;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.stack(Lscala/collection/Iterable;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.str(Ljava/lang/Object;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.str(Ljava/lang/Object;)Lorg/typelevel/paiges/Doc;.T#
-         |_root_.org.typelevel.paiges.Doc.tabulate(CLjava/lang/String;Lscala/collection/Iterable;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.tabulate(Lscala/collection/immutable/List;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Doc.text(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.TextDocument#
-         |_root_.org.typelevel.paiges.TextDocument#$init$()V.
-         |_root_.org.typelevel.paiges.TextDocument#contramap(Lscala/Function1;)Lorg/typelevel/paiges.TextDocument;.
-         |_root_.org.typelevel.paiges.TextDocument#contramap(Lscala/Function1;)Lorg/typelevel/paiges.TextDocument;.Z#
-         |_root_.org.typelevel.paiges.TextDocument#document(Ljava/lang/Object;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.TextDocument.
-         |_root_.org.typelevel.paiges.TextDocument.FromToString.
-         |_root_.org.typelevel.paiges.TextDocument.FromToString.document(Ljava/lang/Object;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.TextDocument.apply(Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges.TextDocument;.
-         |_root_.org.typelevel.paiges.TextDocument.apply(Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges.TextDocument;.A#
-         |_root_.org.typelevel.paiges.TextDocument.documentBoolean.
-         |_root_.org.typelevel.paiges.TextDocument.documentByte.
-         |_root_.org.typelevel.paiges.TextDocument.documentChar.
-         |_root_.org.typelevel.paiges.TextDocument.documentDouble.
-         |_root_.org.typelevel.paiges.TextDocument.documentFloat.
-         |_root_.org.typelevel.paiges.TextDocument.documentInt.
-         |_root_.org.typelevel.paiges.TextDocument.documentIterable(Ljava/lang/String;Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges.TextDocument;.
-         |_root_.org.typelevel.paiges.TextDocument.documentIterable(Ljava/lang/String;Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges.TextDocument;.A#
-         |_root_.org.typelevel.paiges.TextDocument.documentLong.
-         |_root_.org.typelevel.paiges.TextDocument.documentShort.
-         |_root_.org.typelevel.paiges.TextDocument.documentString.
-         |_root_.org.typelevel.paiges.TextDocument.documentUnit.
-         |_root_.org.typelevel.paiges.TextDocument.instance(Lscala/Function1;)Lorg/typelevel/paiges.TextDocument;.
-         |_root_.org.typelevel.paiges.TextDocument.instance(Lscala/Function1;)Lorg/typelevel/paiges.TextDocument;.A#
-         |_root_.org.typelevel.paiges.TextDocument.useToString()Lorg/typelevel/paiges.TextDocument;.
-         |_root_.org.typelevel.paiges.TextDocument.useToString()Lorg/typelevel/paiges.TextDocument;.A#
-         |_root_.org.typelevel.paiges.TextDocumentTest#
-         |_root_.org.typelevel.paiges.TextDocumentTest#`<init>`()V.
-         |_root_.org.typelevel.paiges.TextDocumentTest#document(Ljava/lang/Object;Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.TextDocumentTest#document(Ljava/lang/Object;Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges/Doc;.A#
-         |_root_.org.typelevel.paiges.TextDocumentTest#generatorDrivenConfig.
-         |_root_.org.typelevel.paiges.Generators.
-         |_root_.org.typelevel.paiges.Generators.arbDoc.
-         |_root_.org.typelevel.paiges.Generators.asciiString.
-         |_root_.org.typelevel.paiges.Generators.cogenDoc.
-         |_root_.org.typelevel.paiges.Generators.combinators.
-         |_root_.org.typelevel.paiges.Generators.doc0Gen.
-         |_root_.org.typelevel.paiges.Generators.folds.
-         |_root_.org.typelevel.paiges.Generators.genDoc.
-         |_root_.org.typelevel.paiges.Generators.genTree(I)Lorg/scalacheck/Gen;.
-         |_root_.org.typelevel.paiges.Generators.generalString.
-         |_root_.org.typelevel.paiges.Generators.maxDepth.
-         |_root_.org.typelevel.paiges.Generators.unary.
-         |_root_.org.typelevel.paiges.Json#
-         |_root_.org.typelevel.paiges.Json#`<init>`()V.
-         |_root_.org.typelevel.paiges.Json#toDoc()Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Json.
-         |_root_.org.typelevel.paiges.Json.JArray#
-         |_root_.org.typelevel.paiges.Json.JArray#`<init>`(Lscala/collection/immutable/Vector;)V.
-         |_root_.org.typelevel.paiges.Json.JArray#toDoc()Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Json.JArray.
-         |_root_.org.typelevel.paiges.Json.JBool#
-         |_root_.org.typelevel.paiges.Json.JBool#`<init>`(Z)V.
-         |_root_.org.typelevel.paiges.Json.JBool#toDoc()Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Json.JNull.
-         |_root_.org.typelevel.paiges.Json.JNull.toDoc()Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Json.JNumber#
-         |_root_.org.typelevel.paiges.Json.JNumber#`<init>`(D)V.
-         |_root_.org.typelevel.paiges.Json.JNumber#toDoc()Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Json.JNumber.
-         |_root_.org.typelevel.paiges.Json.JObject#
-         |_root_.org.typelevel.paiges.Json.JObject#`<init>`(Lscala/collection/immutable/Map;)V.
-         |_root_.org.typelevel.paiges.Json.JObject#toDoc()Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Json.JString#
-         |_root_.org.typelevel.paiges.Json.JString#`<init>`(Ljava/lang/String;)V.
-         |_root_.org.typelevel.paiges.Json.JString#toDoc()Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Json.JString.
-         |_root_.org.typelevel.paiges.Json.escape(Ljava/lang/String;)Ljava/lang/String;.
-         |_root_.org.typelevel.paiges.JsonTest#
-         |_root_.org.typelevel.paiges.JsonTest#`<init>`()V.
-         |_root_.org.typelevel.paiges.PaigesTest#
-         |_root_.org.typelevel.paiges.PaigesTest#`<init>`()V.
-         |_root_.org.typelevel.paiges.PaigesTest#generatorDrivenConfig.
-         |_root_.org.typelevel.paiges.PaigesTest.
-         |_root_.org.typelevel.paiges.PaigesTest.EquivSyntax#
-         |_root_.org.typelevel.paiges.PaigesTest.EquivSyntax#`<init>`(Lorg/typelevel/paiges/Doc;)V.
-         |_root_.org.typelevel.paiges.PaigesTest.EquivSyntax#`===`(Lorg/typelevel/paiges/Doc;)Z.
-         |_root_.org.typelevel.paiges.PaigesTest.docEquiv.
-         |_root_.org.typelevel.paiges.PaigesTest.docEquiv.$anon#equiv(Lorg/typelevel/paiges/Doc;Lorg/typelevel/paiges/Doc;)Z.
-         |_root_.org.typelevel.paiges.package.
-         |_root_.org.typelevel.paiges.package.call(Ljava/lang/Object;Lscala/collection/immutable/List;)Ljava/lang/Object;.
-         |_root_.org.typelevel.paiges.package.call(Ljava/lang/Object;Lscala/collection/immutable/List;)Ljava/lang/Object;.A#
+      """|
+         |org.typelevel.paiges.Chunk.
+         |org.typelevel.paiges.Chunk.best(Int,Doc).
+         |org.typelevel.paiges.Chunk.indentMax.
+         |org.typelevel.paiges.Chunk.indentTable.
+         |org.typelevel.paiges.Chunk.lineToStr(Int).
+         |org.typelevel.paiges.Chunk.makeIndentStr(Int).
+         |org.typelevel.paiges.Doc#
+         |org.typelevel.paiges.Doc#`&:`(String).
+         |org.typelevel.paiges.Doc#`&`(Doc).
+         |org.typelevel.paiges.Doc#`*`(Int).
+         |org.typelevel.paiges.Doc#`+:`(String).
+         |org.typelevel.paiges.Doc#`+`(Doc).
+         |org.typelevel.paiges.Doc#`/:`(String).
+         |org.typelevel.paiges.Doc#`/`(Doc).
+         |org.typelevel.paiges.Doc#`:&`(String).
+         |org.typelevel.paiges.Doc#`:+`(String).
+         |org.typelevel.paiges.Doc#`:/`(String).
+         |org.typelevel.paiges.Doc#`<init>`().
+         |org.typelevel.paiges.Doc#aligned().
+         |org.typelevel.paiges.Doc#bracketBy(Doc,Doc,Int).
+         |org.typelevel.paiges.Doc#flatten().
+         |org.typelevel.paiges.Doc#flattenBoolean().
+         |org.typelevel.paiges.Doc#flattenOption().
+         |org.typelevel.paiges.Doc#grouped().
+         |org.typelevel.paiges.Doc#hashCode().
+         |org.typelevel.paiges.Doc#isEmpty().
+         |org.typelevel.paiges.Doc#line(Doc).
+         |org.typelevel.paiges.Doc#line(String).
+         |org.typelevel.paiges.Doc#lineOrSpace(Doc).
+         |org.typelevel.paiges.Doc#lineOrSpace(String).
+         |org.typelevel.paiges.Doc#maxWidth().
+         |org.typelevel.paiges.Doc#nested(Int).
+         |org.typelevel.paiges.Doc#nonEmpty().
+         |org.typelevel.paiges.Doc#render(Int).
+         |org.typelevel.paiges.Doc#renderStream(Int).
+         |org.typelevel.paiges.Doc#renderWideStream().
+         |org.typelevel.paiges.Doc#repeat(Int).
+         |org.typelevel.paiges.Doc#representation(Boolean).
+         |org.typelevel.paiges.Doc#space(Doc).
+         |org.typelevel.paiges.Doc#space(String).
+         |org.typelevel.paiges.Doc#tightBracketBy(Doc,Doc,Int).
+         |org.typelevel.paiges.Doc#toString().
+         |org.typelevel.paiges.Doc#writeTo(Int,PrintWriter).
+         |org.typelevel.paiges.Doc.
+         |org.typelevel.paiges.Doc.Align#
+         |org.typelevel.paiges.Doc.Align#`<init>`(Doc).
+         |org.typelevel.paiges.Doc.Align#doc().
+         |org.typelevel.paiges.Doc.Align.
+         |org.typelevel.paiges.Doc.Concat#
+         |org.typelevel.paiges.Doc.Concat#`<init>`(Doc,Doc).
+         |org.typelevel.paiges.Doc.Concat#a().
+         |org.typelevel.paiges.Doc.Concat#b().
+         |org.typelevel.paiges.Doc.Concat.
+         |org.typelevel.paiges.Doc.Empty.
+         |org.typelevel.paiges.Doc.Line#
+         |org.typelevel.paiges.Doc.Line#`<init>`(Boolean).
+         |org.typelevel.paiges.Doc.Line#asFlatDoc().
+         |org.typelevel.paiges.Doc.Line#flattenToSpace().
+         |org.typelevel.paiges.Doc.Line.
+         |org.typelevel.paiges.Doc.Nest#
+         |org.typelevel.paiges.Doc.Nest#`<init>`(Int,Doc).
+         |org.typelevel.paiges.Doc.Nest#doc().
+         |org.typelevel.paiges.Doc.Nest#indent().
+         |org.typelevel.paiges.Doc.Nest.
+         |org.typelevel.paiges.Doc.Text#
+         |org.typelevel.paiges.Doc.Text#`<init>`(String).
+         |org.typelevel.paiges.Doc.Text#str().
+         |org.typelevel.paiges.Doc.Text.
+         |org.typelevel.paiges.Doc.Union#
+         |org.typelevel.paiges.Doc.Union#`<init>`(Doc,Function0).
+         |org.typelevel.paiges.Doc.Union#a().
+         |org.typelevel.paiges.Doc.Union#b().
+         |org.typelevel.paiges.Doc.Union#bDoc().
+         |org.typelevel.paiges.Doc.Union.
+         |org.typelevel.paiges.Doc.cat(Iterable).
+         |org.typelevel.paiges.Doc.char(Char).
+         |org.typelevel.paiges.Doc.charTable.
+         |org.typelevel.paiges.Doc.comma().
+         |org.typelevel.paiges.Doc.empty().
+         |org.typelevel.paiges.Doc.equivAtWidths(List).
+         |org.typelevel.paiges.Doc.fill(Doc,Iterable).
+         |org.typelevel.paiges.Doc.foldDocs(Iterable,Function2).
+         |org.typelevel.paiges.Doc.intercalate(Doc,Iterable).
+         |org.typelevel.paiges.Doc.line().
+         |org.typelevel.paiges.Doc.lineBreak().
+         |org.typelevel.paiges.Doc.lineOrEmpty().
+         |org.typelevel.paiges.Doc.lineOrSpace().
+         |org.typelevel.paiges.Doc.maxSpaceTable.
+         |org.typelevel.paiges.Doc.orderingAtWidth(Int).
+         |org.typelevel.paiges.Doc.paragraph(String).
+         |org.typelevel.paiges.Doc.space().
+         |org.typelevel.paiges.Doc.spaceArray.
+         |org.typelevel.paiges.Doc.spaces(Int).
+         |org.typelevel.paiges.Doc.split(String,Regex,Doc).
+         |org.typelevel.paiges.Doc.splitWhitespace().
+         |org.typelevel.paiges.Doc.spread(Iterable).
+         |org.typelevel.paiges.Doc.stack(Iterable).
+         |org.typelevel.paiges.Doc.str(T).
+         |org.typelevel.paiges.Doc.tabulate(Char,String,Iterable).
+         |org.typelevel.paiges.Doc.tabulate(List).
+         |org.typelevel.paiges.Doc.text(String).
+         |org.typelevel.paiges.Document#
+         |org.typelevel.paiges.Document#$init$().
+         |org.typelevel.paiges.Document#contramap(Function1).
+         |org.typelevel.paiges.Document#document(A).
+         |org.typelevel.paiges.Document.
+         |org.typelevel.paiges.Document.FromToString.
+         |org.typelevel.paiges.Document.FromToString.document(Any).
+         |org.typelevel.paiges.Document.apply(Document).
+         |org.typelevel.paiges.Document.documentBoolean().
+         |org.typelevel.paiges.Document.documentByte().
+         |org.typelevel.paiges.Document.documentChar().
+         |org.typelevel.paiges.Document.documentDouble().
+         |org.typelevel.paiges.Document.documentFloat().
+         |org.typelevel.paiges.Document.documentInt().
+         |org.typelevel.paiges.Document.documentIterable(String,Document).
+         |org.typelevel.paiges.Document.documentLong().
+         |org.typelevel.paiges.Document.documentShort().
+         |org.typelevel.paiges.Document.documentString().
+         |org.typelevel.paiges.Document.documentUnit().
+         |org.typelevel.paiges.Document.instance(Function1).
+         |org.typelevel.paiges.Document.useToString().
+         |org.typelevel.paiges.DocumentTest#
+         |org.typelevel.paiges.DocumentTest#`<init>`().
+         |org.typelevel.paiges.DocumentTest#document(A,Document).
+         |org.typelevel.paiges.DocumentTest#generatorDrivenConfig().
+         |org.typelevel.paiges.Generators.
+         |org.typelevel.paiges.Generators.arbDoc().
+         |org.typelevel.paiges.Generators.asciiString().
+         |org.typelevel.paiges.Generators.cogenDoc().
+         |org.typelevel.paiges.Generators.combinators().
+         |org.typelevel.paiges.Generators.doc0Gen().
+         |org.typelevel.paiges.Generators.folds().
+         |org.typelevel.paiges.Generators.genDoc().
+         |org.typelevel.paiges.Generators.genTree(Int).
+         |org.typelevel.paiges.Generators.generalString().
+         |org.typelevel.paiges.Generators.maxDepth().
+         |org.typelevel.paiges.Generators.unary().
+         |org.typelevel.paiges.Json#
+         |org.typelevel.paiges.Json#`<init>`().
+         |org.typelevel.paiges.Json#toDoc().
+         |org.typelevel.paiges.Json.
+         |org.typelevel.paiges.Json.JArray#
+         |org.typelevel.paiges.Json.JArray#`<init>`(Vector).
+         |org.typelevel.paiges.Json.JArray#toDoc().
+         |org.typelevel.paiges.Json.JArray#toVector().
+         |org.typelevel.paiges.Json.JArray.
+         |org.typelevel.paiges.Json.JBool#
+         |org.typelevel.paiges.Json.JBool#`<init>`(Boolean).
+         |org.typelevel.paiges.Json.JBool#toBoolean().
+         |org.typelevel.paiges.Json.JBool#toDoc().
+         |org.typelevel.paiges.Json.JNull.
+         |org.typelevel.paiges.Json.JNull.toDoc().
+         |org.typelevel.paiges.Json.JNumber#
+         |org.typelevel.paiges.Json.JNumber#`<init>`(Double).
+         |org.typelevel.paiges.Json.JNumber#toDoc().
+         |org.typelevel.paiges.Json.JNumber#toDouble().
+         |org.typelevel.paiges.Json.JNumber.
+         |org.typelevel.paiges.Json.JObject#
+         |org.typelevel.paiges.Json.JObject#`<init>`(Map).
+         |org.typelevel.paiges.Json.JObject#toDoc().
+         |org.typelevel.paiges.Json.JObject#toMap().
+         |org.typelevel.paiges.Json.JString#
+         |org.typelevel.paiges.Json.JString#`<init>`(String).
+         |org.typelevel.paiges.Json.JString#str().
+         |org.typelevel.paiges.Json.JString#toDoc().
+         |org.typelevel.paiges.Json.JString.
+         |org.typelevel.paiges.Json.escape(String).
+         |org.typelevel.paiges.JsonTest#
+         |org.typelevel.paiges.JsonTest#`<init>`().
+         |org.typelevel.paiges.PaigesTest#
+         |org.typelevel.paiges.PaigesTest#`<init>`().
+         |org.typelevel.paiges.PaigesTest#generatorDrivenConfig().
+         |org.typelevel.paiges.PaigesTest.
+         |org.typelevel.paiges.PaigesTest.EquivSyntax#
+         |org.typelevel.paiges.PaigesTest.EquivSyntax#`<init>`(Doc).
+         |org.typelevel.paiges.PaigesTest.EquivSyntax#`===`(Doc).
+         |org.typelevel.paiges.PaigesTest.EquivSyntax#lhs.
+         |org.typelevel.paiges.PaigesTest.docEquiv().
+         |org.typelevel.paiges.PaigesTest.docEquiv.$anon#equiv(Doc,Doc).
+         |org.typelevel.paiges.package.
+         |org.typelevel.paiges.package.call(A,List).
       """.stripMargin
 
     assertNoDiff(obtained, expected)
@@ -258,30 +266,38 @@ class MetadocCliTest
           .resolve(MetadocCli.encodeSymbolName(id))
           .readAllBytes
       )
-      val obtained = index.toString
+      val obtained = index.toProtoString
+      println(obtained)
+      println()
       assertNoDiff(obtained, expected)
     }
   }
 
   checkSymbolIndex(
-    "_root_.org.typelevel.paiges.Json.JArray.",
+    "org.typelevel.paiges.Json.JArray.",
     """
-        |symbol: "_root_.org.typelevel.paiges.Json.JArray."
+        |symbol: "org.typelevel.paiges.Json.JArray."
         |definition {
         |  filename: "paiges/core/src/test/scala/org/typelevel/paiges/JsonTest.scala"
-        |  start: 711
-        |  end: 717
+        |  startLine: 34
+        |  startCharacter: 13
+        |  endLine: 34
+        |  endCharacter: 19
         |}
         |references {
         |  key: "paiges/core/src/test/scala/org/typelevel/paiges/JsonTest.scala"
         |  value {
         |    ranges {
-        |      start: 1421
-        |      end: 1427
+        |      startLine: 56
+        |      startCharacter: 16
+        |      endLine: 56
+        |      endCharacter: 22
         |    }
         |    ranges {
-        |      start: 1345
-        |      end: 1351
+        |      startLine: 55
+        |      startCharacter: 16
+        |      endLine: 55
+        |      endCharacter: 22
         |    }
         |  }
         |}
@@ -289,29 +305,36 @@ class MetadocCliTest
   )
 
   checkSymbolIndex(
-    "_root_.org.typelevel.paiges.Json.JArray#",
+    "org.typelevel.paiges.Json.JArray#",
     """
-      |symbol: "_root_.org.typelevel.paiges.Json.JArray#"
+      |symbol: "org.typelevel.paiges.Json.JArray#"
       |definition {
       |  filename: "paiges/core/src/test/scala/org/typelevel/paiges/JsonTest.scala"
-      |  start: 711
-      |  end: 717
+      |  startLine: 34
+      |  startCharacter: 13
+      |  endLine: 34
+      |  endCharacter: 19
       |}
       |references {
       |  key: "paiges/core/src/test/scala/org/typelevel/paiges/JsonTest.scala"
       |  value {
       |    ranges {
-      |      start: 1421
-      |      end: 1427
+      |      startLine: 56
+      |      startCharacter: 16
+      |      endLine: 56
+      |      endCharacter: 22
       |    }
       |    ranges {
-      |      start: 1345
-      |      end: 1351
+      |      startLine: 55
+      |      startCharacter: 16
+      |      endLine: 55
+      |      endCharacter: 22
       |    }
       |  }
       |}
       |""".stripMargin
   )
+
   test("--clean-target-first") {
     runCli() // assert no error
   }

--- a/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
@@ -34,9 +34,9 @@ class MetadocCliTest
   val expectedFiles =
     """paiges/core/src/main/scala/org/typelevel/paiges/Chunk.scala.semanticdb
       |paiges/core/src/main/scala/org/typelevel/paiges/Doc.scala.semanticdb
-      |paiges/core/src/main/scala/org/typelevel/paiges/Document.scala.semanticdb
+      |paiges/core/src/main/scala/org/typelevel/paiges.TextDocument.scala.semanticdb
       |paiges/core/src/main/scala/org/typelevel/paiges/package.scala.semanticdb
-      |paiges/core/src/test/scala/org/typelevel/paiges/DocumentTests.scala.semanticdb
+      |paiges/core/src/test/scala/org/typelevel/paiges.TextDocumentTests.scala.semanticdb
       |paiges/core/src/test/scala/org/typelevel/paiges/Generators.scala.semanticdb
       |paiges/core/src/test/scala/org/typelevel/paiges/JsonTest.scala.semanticdb
       |paiges/core/src/test/scala/org/typelevel/paiges/PaigesTest.scala.semanticdb
@@ -153,37 +153,37 @@ class MetadocCliTest
          |_root_.org.typelevel.paiges.Doc.tabulate(CLjava/lang/String;Lscala/collection/Iterable;)Lorg/typelevel/paiges/Doc;.
          |_root_.org.typelevel.paiges.Doc.tabulate(Lscala/collection/immutable/List;)Lorg/typelevel/paiges/Doc;.
          |_root_.org.typelevel.paiges.Doc.text(Ljava/lang/String;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Document#
-         |_root_.org.typelevel.paiges.Document#$init$()V.
-         |_root_.org.typelevel.paiges.Document#contramap(Lscala/Function1;)Lorg/typelevel/paiges/Document;.
-         |_root_.org.typelevel.paiges.Document#contramap(Lscala/Function1;)Lorg/typelevel/paiges/Document;.Z#
-         |_root_.org.typelevel.paiges.Document#document(Ljava/lang/Object;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Document.
-         |_root_.org.typelevel.paiges.Document.FromToString.
-         |_root_.org.typelevel.paiges.Document.FromToString.document(Ljava/lang/Object;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.Document.apply(Lorg/typelevel/paiges/Document;)Lorg/typelevel/paiges/Document;.
-         |_root_.org.typelevel.paiges.Document.apply(Lorg/typelevel/paiges/Document;)Lorg/typelevel/paiges/Document;.A#
-         |_root_.org.typelevel.paiges.Document.documentBoolean.
-         |_root_.org.typelevel.paiges.Document.documentByte.
-         |_root_.org.typelevel.paiges.Document.documentChar.
-         |_root_.org.typelevel.paiges.Document.documentDouble.
-         |_root_.org.typelevel.paiges.Document.documentFloat.
-         |_root_.org.typelevel.paiges.Document.documentInt.
-         |_root_.org.typelevel.paiges.Document.documentIterable(Ljava/lang/String;Lorg/typelevel/paiges/Document;)Lorg/typelevel/paiges/Document;.
-         |_root_.org.typelevel.paiges.Document.documentIterable(Ljava/lang/String;Lorg/typelevel/paiges/Document;)Lorg/typelevel/paiges/Document;.A#
-         |_root_.org.typelevel.paiges.Document.documentLong.
-         |_root_.org.typelevel.paiges.Document.documentShort.
-         |_root_.org.typelevel.paiges.Document.documentString.
-         |_root_.org.typelevel.paiges.Document.documentUnit.
-         |_root_.org.typelevel.paiges.Document.instance(Lscala/Function1;)Lorg/typelevel/paiges/Document;.
-         |_root_.org.typelevel.paiges.Document.instance(Lscala/Function1;)Lorg/typelevel/paiges/Document;.A#
-         |_root_.org.typelevel.paiges.Document.useToString()Lorg/typelevel/paiges/Document;.
-         |_root_.org.typelevel.paiges.Document.useToString()Lorg/typelevel/paiges/Document;.A#
-         |_root_.org.typelevel.paiges.DocumentTest#
-         |_root_.org.typelevel.paiges.DocumentTest#`<init>`()V.
-         |_root_.org.typelevel.paiges.DocumentTest#document(Ljava/lang/Object;Lorg/typelevel/paiges/Document;)Lorg/typelevel/paiges/Doc;.
-         |_root_.org.typelevel.paiges.DocumentTest#document(Ljava/lang/Object;Lorg/typelevel/paiges/Document;)Lorg/typelevel/paiges/Doc;.A#
-         |_root_.org.typelevel.paiges.DocumentTest#generatorDrivenConfig.
+         |_root_.org.typelevel.paiges.TextDocument#
+         |_root_.org.typelevel.paiges.TextDocument#$init$()V.
+         |_root_.org.typelevel.paiges.TextDocument#contramap(Lscala/Function1;)Lorg/typelevel/paiges.TextDocument;.
+         |_root_.org.typelevel.paiges.TextDocument#contramap(Lscala/Function1;)Lorg/typelevel/paiges.TextDocument;.Z#
+         |_root_.org.typelevel.paiges.TextDocument#document(Ljava/lang/Object;)Lorg/typelevel/paiges/Doc;.
+         |_root_.org.typelevel.paiges.TextDocument.
+         |_root_.org.typelevel.paiges.TextDocument.FromToString.
+         |_root_.org.typelevel.paiges.TextDocument.FromToString.document(Ljava/lang/Object;)Lorg/typelevel/paiges/Doc;.
+         |_root_.org.typelevel.paiges.TextDocument.apply(Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges.TextDocument;.
+         |_root_.org.typelevel.paiges.TextDocument.apply(Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges.TextDocument;.A#
+         |_root_.org.typelevel.paiges.TextDocument.documentBoolean.
+         |_root_.org.typelevel.paiges.TextDocument.documentByte.
+         |_root_.org.typelevel.paiges.TextDocument.documentChar.
+         |_root_.org.typelevel.paiges.TextDocument.documentDouble.
+         |_root_.org.typelevel.paiges.TextDocument.documentFloat.
+         |_root_.org.typelevel.paiges.TextDocument.documentInt.
+         |_root_.org.typelevel.paiges.TextDocument.documentIterable(Ljava/lang/String;Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges.TextDocument;.
+         |_root_.org.typelevel.paiges.TextDocument.documentIterable(Ljava/lang/String;Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges.TextDocument;.A#
+         |_root_.org.typelevel.paiges.TextDocument.documentLong.
+         |_root_.org.typelevel.paiges.TextDocument.documentShort.
+         |_root_.org.typelevel.paiges.TextDocument.documentString.
+         |_root_.org.typelevel.paiges.TextDocument.documentUnit.
+         |_root_.org.typelevel.paiges.TextDocument.instance(Lscala/Function1;)Lorg/typelevel/paiges.TextDocument;.
+         |_root_.org.typelevel.paiges.TextDocument.instance(Lscala/Function1;)Lorg/typelevel/paiges.TextDocument;.A#
+         |_root_.org.typelevel.paiges.TextDocument.useToString()Lorg/typelevel/paiges.TextDocument;.
+         |_root_.org.typelevel.paiges.TextDocument.useToString()Lorg/typelevel/paiges.TextDocument;.A#
+         |_root_.org.typelevel.paiges.TextDocumentTest#
+         |_root_.org.typelevel.paiges.TextDocumentTest#`<init>`()V.
+         |_root_.org.typelevel.paiges.TextDocumentTest#document(Ljava/lang/Object;Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges/Doc;.
+         |_root_.org.typelevel.paiges.TextDocumentTest#document(Ljava/lang/Object;Lorg/typelevel/paiges.TextDocument;)Lorg/typelevel/paiges/Doc;.A#
+         |_root_.org.typelevel.paiges.TextDocumentTest#generatorDrivenConfig.
          |_root_.org.typelevel.paiges.Generators.
          |_root_.org.typelevel.paiges.Generators.arbDoc.
          |_root_.org.typelevel.paiges.Generators.asciiString.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,13 +3,11 @@ addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.1.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
-addSbtPlugin(
-  "com.thesamet" % "sbt-protoc" % "0.99.14" exclude ("com.trueaccord.scalapb", "protoc-bridge_2.10")
-)
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
 addSbtPlugin(
   "io.get-coursier" % "sbt-coursier" % coursier.util.Properties.version
 )
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin-shaded" % "0.6.6"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.1"
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
Supersedes #84. I was struggling to debug why #84 was failing in manual tests, goto definition, find references didn't work. I went ahead and migrated from scratch and everything works now. I encountered an off-by-one bug in positions when manually testing the site, but otherwise everything worked out nicely.

One regression that I leave for a future PR is that signatures ("containerName") for "document symbol" no longer show result types

<img width="283" alt="screen shot 2018-04-08 at 14 47 50" src="https://user-images.githubusercontent.com/1408093/38467650-0f615182-3b3c-11e8-9a1c-680ce689e589.png">

Metap does not expose an API to pretty print a single `SymbolInformation.tpe`.