### PR TITLE
Fix navigation state management

### DIFF
--- a/metadoc-js/src/main/scala/metadoc/MetadocApp.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocApp.scala
@@ -71,7 +71,7 @@ object MetadocApp {
           .orElse(defaultState)
 
       dom.window.onpopstate = { e: dom.PopStateEvent =>
-        for (state <- Navigation.currentState())
+        for (state <- Navigation.currentState(e.state))
           openEditor(editorService)(state)
       }
 
@@ -86,11 +86,12 @@ object MetadocApp {
   def updateHistory(state: Navigation.State): Unit = {
     val uri = "#/" + state.toString.dropWhile(_ == '/')
 
-    Navigation.currentState() match {
+    Navigation.currentState(dom.window.history.state) match {
       case Some(cur) if cur.path == state.path =>
-        dom.window.history.replaceState(state, state.path, uri)
+        dom.window.history.replaceState(state.toString, state.path, uri)
       case _ =>
-        dom.window.history.pushState(state, state.path, uri)
+        updateTitle(state)
+        dom.window.history.pushState(state.toString, state.path, uri)
     }
   }
 

--- a/metadoc-js/src/test/scala/metadoc/NavigationTest.scala
+++ b/metadoc-js/src/test/scala/metadoc/NavigationTest.scala
@@ -15,7 +15,7 @@ class NavigationTest extends FunSuite {
     assert(stateWithSelection.get.path == "/path2")
     assert(
       stateWithSelection.get.selection == Some(
-        Navigation.Selection(11, 1, 12, 1)
+        Navigation.Selection(11, 1, 11, 1)
       )
     )
 
@@ -23,31 +23,28 @@ class NavigationTest extends FunSuite {
     assert(Navigation.parseState("#/path2#L11").isEmpty)
   }
 
-  test("Navigation.currentState") {
-    val stateFromHash = Navigation.currentState(None, "/path")
-    assert(stateFromHash.isDefined)
+  test("Navigation.fromHistoryState") {
+    val noState = Navigation.fromHistoryState(null)
+    assert(noState.isEmpty)
+
+    val stateFromHash = Navigation.fromHistoryState("/path")
+    assert(stateFromHash.nonEmpty)
     assert(stateFromHash.get.path == "/path")
     assert(stateFromHash.get.selection.isEmpty)
 
-    val stateFromHashWithSelection =
-      Navigation.currentState(None, "/path2#L11")
+    val stateFromHashWithSelection = Navigation.fromHistoryState("/path2#L11")
     assert(stateFromHashWithSelection.isDefined)
     assert(stateFromHashWithSelection.get.path == "/path2")
     assert(
       stateFromHashWithSelection.get.selection == Some(
-        Navigation.Selection(11, 1, 12, 1)
+        Navigation.Selection(11, 1, 11, 1)
       )
     )
-
-    val stateFromHistory =
-      Navigation.currentState(stateFromHash, "/other-path")
-    assert(stateFromHistory.isDefined)
-    assert(stateFromHistory.get.path == "/path")
-    assert(stateFromHistory.get.selection.isEmpty)
   }
 
   test("Navigation.Selection.toString") {
-    assert(Navigation.Selection(11, 1, 12, 1).toString == "L11")
+    assert(Navigation.Selection(11, 1, 11, 1).toString == "L11")
+    assert(Navigation.Selection(11, 4, 11, 4).toString == "L11C4")
     assert(Navigation.Selection(11, 1, 12, 4).toString == "L11-L12C4")
     assert(Navigation.Selection(11, 2, 12, 4).toString == "L11C2-L12C4")
     assert(Navigation.Selection(11, 2, 12, 1).toString == "L11C2-L12")
@@ -65,7 +62,6 @@ class NavigationTest extends FunSuite {
 
   test("Navigation.parseSelection normalization") {
     val selection = Navigation.Selection(1, 1, 2, 1)
-    assert(Navigation.parseSelection("L1") == Some(selection))
     assert(Navigation.parseSelection("L1-L2") == Some(selection))
     assert(Navigation.parseSelection("L1C1-L2") == Some(selection))
     assert(Navigation.parseSelection("L1-L2C1") == Some(selection))
@@ -75,17 +71,19 @@ class NavigationTest extends FunSuite {
   test("Navigation.parseSelection roundtrip") {
     val samples =
       """L1
+        |L1C2
         |L1-L3
         |L1C2-L2
         |L1-L1C2
         |L110-L112C25
+        |L110C42-L112C25
         |
         |L10-L2
         |"""
 
     samples.stripMargin.split('\n').filter(_.nonEmpty).foreach { selection =>
       assert(
-        Navigation.parseSelection(selection).map(_.toString) == Some(selection)
+        Some(selection) == Navigation.parseSelection(selection).map(_.toString)
       )
     }
   }


### PR DESCRIPTION
State management was broken in Chrome.

Changes the app to store the state as a string instead of a JavaScript object, because it looks like Chrome drops some of the annotations or structure required by Scala.js. Had to fix a bug in the state parsing to ensure that we can restore to the same selection.